### PR TITLE
トレーニングカテゴリのテスト追加

### DIFF
--- a/treco-web/e2e/training-category.test.ts
+++ b/treco-web/e2e/training-category.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import { randomUUID } from 'crypto';
+
+test('トレーニングカテゴリーを作成・編集・編集できる', async ({ page }) => {
+  await page.goto('/home');
+  await page.getByRole('link', { name: 'トレーニング記録へのリンク' }).click();
+
+  // トレーニングカテゴリー作成
+  await page
+    .getByRole('button', { name: 'トレーニングカテゴリーを作成する' })
+    .click();
+  const oldName = randomUUID();
+  const oldColor = '#555555';
+  await page.getByRole('textbox', { name: '名前' }).fill(oldName);
+  await page.getByLabel('カラー').fill(oldColor);
+  await page.getByRole('button', { name: '保存する' }).click();
+
+  // 末尾に追加されていることを確認
+  const lastCategoryItem = page
+    .getByRole('list', { name: 'カテゴリーリスト' })
+    .getByRole('listitem')
+    .last();
+  await expect(lastCategoryItem).toContainText(oldName);
+  // TODO: 色のテスト
+
+  // トレーニングカテゴリー編集
+  await lastCategoryItem
+    .getByRole('button', { name: 'カテゴリ名編集' })
+    .click();
+  const newName = randomUUID();
+  const newColor = '#333333';
+  await page.getByRole('textbox', { name: '名前' }).fill(newName);
+  await page.getByLabel('カラー').fill(newColor);
+  await page.getByRole('button', { name: '保存する' }).click();
+
+  // 編集されていることを確認
+  await expect(lastCategoryItem).toContainText(newName);
+  // TODO: 色のテスト
+
+  // TODO: swipe したら削除ボタンが表示されるテスト
+
+  // 削除
+  await lastCategoryItem.getByRole('button', { name: '削除' }).click();
+  await page
+    .getByRole('button', { name: 'トレーニングカテゴリーを削除する' })
+    .click();
+
+  await expect(lastCategoryItem).not.toContainText(newName);
+});

--- a/treco-web/e2e/training-record.test.ts
+++ b/treco-web/e2e/training-record.test.ts
@@ -1,12 +1,5 @@
 import { expect, test } from '@playwright/test';
 
-// test('未ログインの場合ホームにリダイレクトする', async ({ page }) => {
-//   await page.context().clearCookies();
-//   await page.goto(path);
-
-//   await expect(page).toHaveURL('/');
-// });
-
 test('トレーニングセットを記録できる', async ({ page }) => {
   // トレーニング記録ページへ移動
   await page.goto('/home');

--- a/treco-web/src/app/(header)/(auth)/home/categories/_components/category-delete.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/_components/category-delete.tsx
@@ -37,6 +37,7 @@ export function CategoryDelete({ trainingCategoryId }: Props) {
     <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
       <AlertDialogTrigger asChild>
         <Button className="h-full" variant="destructive">
+          <span className="sr-only">削除</span>
           <TrashIcon aria-hidden="true" className="h-12 w-14" />
         </Button>
       </AlertDialogTrigger>

--- a/treco-web/src/app/(header)/(auth)/home/categories/_components/category-edit.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/_components/category-edit.tsx
@@ -86,14 +86,23 @@ export function CategoryEdit(props: Props) {
         </DialogHeader>
         <div className="grid gap-2">
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label className="text-right">名前</Label>
-            <Input className="col-span-3" {...form.register('name')} />
+            <Label className="text-right" id="name">
+              名前
+            </Label>
+            <Input
+              className="col-span-3"
+              {...form.register('name')}
+              aria-labelledby="name"
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label className="text-right">カラー</Label>
+            <Label className="text-right" id="color">
+              カラー
+            </Label>
             <Input
               className="col-span-3"
               {...form.register('color')}
+              aria-labelledby="color"
               type="color"
             />
           </div>

--- a/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
@@ -35,7 +35,7 @@ export default async function CategoryPage({ searchParams }: Props) {
       </p>
 
       <ul
-        aria-label="トレーニングカテゴリー"
+        aria-label="トレーニングカテゴリーリスト"
         className="flex w-full flex-col gap-2"
       >
         {categories.length ? (


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更に関するリリースノートの要約です：

1. treco-web/e2e/training-category.test.ts:
   - トレーニングカテゴリーを作成、編集、削除するテストを追加しました。
   - テストでは、ページ上の要素を操作して新しいカテゴリーを作成、編集、削除することを確認します。

2. treco-web/e2e/training-record.test.ts:
   - 未ログインの場合のリダイレクトテストを削除し、代わりにトレーニングセットを記録するテストを追加しました。
   - 新しいテストでは、ユーザーがトレーニングセットを記録できることを確認します。

3. treco-web/src/app/(header)/(auth)/home/categories/_components/category-delete.tsx:
   - トレーニングカテゴリを削除するボタンのアクセシビリティを改善しました。
   - `CategoryDelete`コンポーネント内の削除ボタンに`<span>`要素を追加し、スクリーンリーダーによる読み上げ時に「削除」というテキストが表示されるようになります。

4. treco-web/src/app/(header)/(auth)/home/categories/_components/category-edit.tsx:
   - トレーニングカテゴリの編集フォームのアクセシビリティを改善しました。
   - `名前`と`カラー`の入力フィールドに対して、それぞれのラベルを追加し、`aria-labelledby`属性を設定しました。

5. treco-web/src/app/(header)/(auth)/home/categories/page.tsx:
   - `CategoryPage`コンポーネントのリスト要素の`aria-label`属性を変更しました。
   - 以前は「トレーニングカテゴリー」と設定されていましたが、新しい値は「トレーニングカテゴリーリスト」です。

以上が変更の要点です。これらの変更は、トレーニングカテゴリー関連の機能やアクセシビリティの改善に焦点を当てています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->