### PR TITLE
トレーニングカテゴリーのテストをリファクタリング

### DIFF
--- a/treco-web/e2e/pages/training-category.page.ts
+++ b/treco-web/e2e/pages/training-category.page.ts
@@ -1,0 +1,67 @@
+import { Locator, Page } from '@playwright/test';
+
+export class TrainingCategoryPage {
+  readonly trainingCategoryItems: Locator;
+
+  constructor(private page: Page) {
+    this.trainingCategoryItems = page
+      .getByRole('list', {
+        name: 'トレーニングカテゴリーリスト',
+      })
+      .getByRole('listitem');
+  }
+
+  async addTrainingCategory(trainingCategory: {
+    categoryName: string;
+    color: string;
+  }) {
+    await this.page
+      .getByRole('button', { name: 'トレーニングカテゴリーを作成する' })
+      .click();
+    await this.inputTrainingCategory(trainingCategory);
+    await this.page.getByRole('button', { name: '保存する' }).click();
+  }
+
+  async editTrainingCategory(
+    index: number,
+    trainingCategory: {
+      categoryName: string;
+      color: string;
+    },
+  ) {
+    await this.trainingCategoryItems
+      .nth(index)
+      .getByRole('button', { name: '編集' })
+      .click();
+    await this.inputTrainingCategory(trainingCategory);
+    await this.page.getByRole('button', { name: '保存する' }).click();
+  }
+
+  async goTo() {
+    await this.page.goto('/home');
+    await this.page
+      .getByRole('link', { name: 'トレーニング記録へのリンク' })
+      .click();
+  }
+
+  async inputTrainingCategory({
+    categoryName,
+    color,
+  }: {
+    categoryName: string;
+    color: string;
+  }) {
+    await this.page.getByRole('textbox', { name: '名前' }).fill(categoryName);
+    await this.page.getByLabel('カラー').fill(color);
+  }
+
+  async removeTrainingCategory(index: number) {
+    await this.trainingCategoryItems
+      .nth(index)
+      .getByRole('button', { name: '削除' })
+      .click();
+    await this.page
+      .getByRole('button', { name: 'トレーニングカテゴリーを削除する' })
+      .click();
+  }
+}

--- a/treco-web/e2e/pages/training-event.page.ts
+++ b/treco-web/e2e/pages/training-event.page.ts
@@ -49,7 +49,7 @@ export class TrainingEventPage {
     await this.page.getByRole('button', { name: '保存する' }).click();
   }
 
-  async goToInNewCategories(categoryName: string) {
+  async goToNewCategory(categoryName: string) {
     await this.page.goto('/home');
     await this.page
       .getByRole('link', { name: 'トレーニング記録へのリンク' })

--- a/treco-web/e2e/training-event.test.ts
+++ b/treco-web/e2e/training-event.test.ts
@@ -43,7 +43,7 @@ const test = base.extend<{
     const trainingEventPage = new TrainingEventPage(page);
     // カテゴリを作成
     const categoryName = randomUUID();
-    await trainingEventPage.goToInNewCategories(categoryName);
+    await trainingEventPage.goToNewCategory(categoryName);
 
     // トレーニング種目を作成
     for (const event of events) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

リリースノート:

treco-web/e2e/pages/training-category.page.ts:
- `TrainingCategoryPage`クラスに新しいメソッドが追加されました。これには、トレーニングカテゴリーを追加するための`addTrainingCategory`、トレーニングカテゴリーを編集するための`editTrainingCategory`、ページに移動するための`goTo`、トレーニングカテゴリーを削除するための`removeTrainingCategory`が含まれています。また、`inputTrainingCategory`メソッドも追加され、トレーニングカテゴリーの名前と色を入力するために使用されます。これにより、トレーニングカテゴリーの作成、編集、削除が容易になります。

treco-web/e2e/pages/training-event.page.ts:
- `TrainingEventPage`クラスの`goToInNewCategories`メソッドが`goToNewCategory`にリネームされました。関数名の変更のみであり、外部インターフェースやコードの動作には影響がありません。

treco-web/e2e/training-category.test.ts:
- トレーニングカテゴリーのテストがリファクタリングされました。テストコードがPlaywrightの新しい機能を使用するように変更され、`@playwright/test`パッケージの`test`関数と`expect`関数がインポートされました。また、`TrainingCategoryPage`という新しいページオブジェクトが導入され、トレーニングカテゴリーの作成、編集、削除のテストがそれに基づいて書き直されました。テストの実装方法が変更されたため、外部インターフェースや動作に影響を与える可能性があります。

treco-web/e2e/training-event.test.ts:
- `TrainingEventPage`クラスの`goToInNewCategories`メソッドが`goToNewCategory`にリネームされました。関数のシグネチャや外部インターフェースには影響がありません。この変更は、トレーニングカテゴリーのテストをリファクタリングするためのものであり、機能的な変更は行われていません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->