### PR TITLE
トレーニング記録のテストリファクタリング

### DIFF
--- a/treco-web/e2e/pages/training-record.page.ts
+++ b/treco-web/e2e/pages/training-record.page.ts
@@ -1,0 +1,87 @@
+import { Locator, Page } from '@playwright/test';
+
+export class TrainingRecordPage {
+  readonly trainingSetItems: Locator;
+
+  constructor(private page: Page) {
+    this.trainingSetItems = page
+      .getByRole('list', {
+        name: 'トレーニングセット',
+      })
+      .getByRole('listitem');
+  }
+
+  async addTrainingSet(trainingSet: {
+    load: number;
+    note?: string;
+    value: number;
+  }) {
+    await this.inputTrainingSet(trainingSet);
+    await this.page.getByRole('button', { name: '追加する' }).click();
+  }
+
+  async editTrainingSet(
+    index: number,
+    trainingSet: {
+      load: number;
+      note?: string;
+      value: number;
+    },
+  ) {
+    await this.trainingSetItems
+      .nth(index)
+      .getByRole('button', { name: '編集' })
+      .click();
+
+    // 対象のセットの値が入力フォームに反映する前に入力してしまうため時間を置く
+    // TODO: waitForTimeout を使わない方法を探す
+    await this.page.waitForTimeout(500);
+    await this.inputTrainingSet(trainingSet);
+    await this.page.getByRole('button', { name: '変更する' }).click();
+  }
+
+  async goToNewCategoryEvent(categoryName: string, eventName: string) {
+    await this.page.goto('/home');
+    await this.page
+      .getByRole('link', { name: 'トレーニング記録へのリンク' })
+      .click();
+
+    await this.page
+      .getByRole('button', { name: 'トレーニングカテゴリーを作成する' })
+      .click();
+    await this.page.getByRole('textbox', { name: '名前' }).fill(categoryName);
+    await this.page.getByRole('button', { name: '保存する' }).click();
+    await this.page.getByRole('listitem', { name: categoryName }).click();
+
+    await this.page
+      .getByRole('button', { name: 'トレーニング種目を作成する' })
+      .click();
+    await this.page.getByRole('textbox', { name: '名前' }).fill(eventName);
+    await this.page.getByRole('button', { name: '保存する' }).click();
+    await this.page.getByRole('listitem', { name: eventName }).click();
+  }
+
+  async inputTrainingSet({
+    load,
+    note = '',
+    value,
+  }: {
+    load: number;
+    note?: string;
+    value: number;
+  }) {
+    await this.page.getByRole('spinbutton', { name: '負荷' }).fill(`${load}`);
+    await this.page.getByRole('spinbutton', { name: '値' }).fill(`${value}`);
+    await this.page.getByRole('textbox', { name: '備考' }).fill(note);
+  }
+
+  async removeTrainingSet(index: number) {
+    await this.trainingSetItems
+      .nth(index)
+      .getByRole('button', { name: '削除' })
+      .click();
+    await this.page
+      .getByRole('button', { name: 'トレーニングセットを削除する' })
+      .click();
+  }
+}

--- a/treco-web/e2e/training-record.test.ts
+++ b/treco-web/e2e/training-record.test.ts
@@ -1,120 +1,84 @@
-import { expect, test } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
 
-test('トレーニングセットを記録できる', async ({ page }) => {
-  // トレーニング記録ページへ移動
-  await page.goto('/home');
-  await page.getByRole('link', { name: 'トレーニング記録へのリンク' }).click();
-  await page.getByRole('link', { name: '胸' }).click();
-  await page.getByRole('button', { name: 'ベンチプレス' }).click();
+import { TrainingRecordPage } from './pages/training-record.page';
 
-  // １セット目を記録する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('24.52');
-  await page.getByRole('spinbutton', { name: '値' }).fill('10');
-  await page.getByRole('button', { name: '追加する' }).click();
+const sets = [
+  {
+    load: 24.52,
+    note: '',
+    value: 10,
+  },
+  {
+    load: 20.52,
+    note: '',
+    value: 20,
+  },
+  {
+    load: 24,
+    note: '',
+    value: 30,
+  },
+  {
+    load: 25.0,
+    note: '',
+    value: 40,
+  },
+];
 
-  // ２セット目を記録する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('26.32');
-  await page.getByRole('spinbutton', { name: '値' }).fill('22');
-  await page.getByRole('textbox', { name: '備考' }).fill('追い込み');
-  await page.getByRole('button', { name: '追加する' }).click();
+const test = base.extend<{ trainingRecordPage: TrainingRecordPage }>({
+  trainingRecordPage: async ({ page }, use) => {
+    const trainingRecordPage = new TrainingRecordPage(page);
+    const categoryName = randomUUID();
+    const eventName = randomUUID();
+    await trainingRecordPage.goToNewCategoryEvent(categoryName, eventName);
 
-  // 1セット目が記録されていることを確認
-  const firstSet = page
-    .getByRole('list', { name: 'トレーニングセット' })
-    .getByRole('listitem')
-    .first();
-  await expect(firstSet).toContainText('24.52');
-  await expect(firstSet).toContainText('10');
-  // 備考は未入力の場合はハイフンが表示される
-  await expect(firstSet).toContainText('-');
+    for (const set of sets) {
+      await trainingRecordPage.addTrainingSet(set);
+    }
 
-  // 降順で２セット目が記録されていることを確認
-  const lastSet = page
-    .getByRole('list', { name: 'トレーニングセット' })
-    .getByRole('listitem')
-    .last();
-  await expect(lastSet).toContainText('26.32');
-  await expect(lastSet).toContainText('22');
-  await expect(lastSet).toContainText('追い込み');
+    use(trainingRecordPage);
+  },
 });
 
-test('トレニーニングセットを編集できる', async ({ page }) => {
-  // トレーニング記録ページへ移動
-  await page.goto('/home');
-  await page.getByRole('link', { name: 'トレーニング記録へのリンク' }).click();
-  await page.getByRole('link', { name: '胸' }).click();
-  await page.getByRole('button', { name: 'ベンチプレス' }).click();
-
-  // １セット目を記録する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('24.52');
-  await page.getByRole('spinbutton', { name: '値' }).fill('10');
-  await page.getByRole('button', { name: '追加する' }).click();
-
-  // ２セット目を記録する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('26.32');
-  await page.getByRole('spinbutton', { name: '値' }).fill('22');
-  await page.getByRole('textbox', { name: '備考' }).fill('追い込み');
-  await expect(page.getByRole('button', { name: '追加する' })).toBeEnabled();
-  await page.getByRole('button', { name: '追加する' }).click();
-  await expect(page.getByRole('button', { name: '追加する' })).toBeEnabled();
-
-  // １セット目を選択する
-  const firstSet = page
-    .getByRole('list', { name: 'トレーニングセット' })
-    .getByRole('listitem')
-    .first();
-  await firstSet.getByRole('button', { name: '編集' }).click();
-
-  // フォームに値が反映されていることを確認する
-  await expect(page.getByRole('spinbutton', { name: '負荷' })).toHaveValue(
-    '24.52',
+test('トレーニングセットが追加順に表示される', async ({
+  trainingRecordPage,
+}) => {
+  await Promise.all(
+    sets.map(async (set, index) => {
+      const setItem = trainingRecordPage.trainingSetItems.nth(index);
+      await expect(setItem).toContainText(`${set.load}`);
+      await expect(setItem).toContainText(`${set.value}`);
+      await expect(setItem).toContainText(set.note || '-');
+    }),
   );
-  await expect(page.getByRole('spinbutton', { name: '値' })).toHaveValue('10');
-  await expect(page.getByRole('textbox', { name: '備考' })).toHaveValue('');
-
-  // １セット目を変更する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('30.12');
-  await page.getByRole('spinbutton', { name: '値' }).fill('20');
-  await page.getByRole('textbox', { name: '備考' }).fill('変更');
-  await page.getByRole('button', { name: '変更する' }).click();
-
-  // 1セット目が変更されていることを確認する
-  await expect(firstSet).toContainText('30.12');
-  await expect(firstSet).toContainText('20');
-  await expect(firstSet).toContainText('変更');
 });
 
-test('トレーニングセットを削除できる', async ({ page }) => {
-  // トレーニング記録ページへ移動
-  await page.goto('/home');
-  await page.getByRole('link', { name: 'トレーニング記録へのリンク' }).click();
-  await page.getByRole('link', { name: '胸' }).click();
-  await page.getByRole('button', { name: 'ベンチプレス' }).click();
+test('トレニーニングセットを編集できる', async ({ trainingRecordPage }) => {
+  const editSet = {
+    load: 555,
+    note: 'before',
+    value: 444,
+  };
+  await trainingRecordPage.editTrainingSet(0, editSet);
+  await expect(trainingRecordPage.trainingSetItems.nth(0)).toContainText(
+    `${editSet.load}`,
+  );
+  await expect(trainingRecordPage.trainingSetItems.nth(0)).toContainText(
+    `${editSet.value}`,
+  );
+  await expect(trainingRecordPage.trainingSetItems.nth(0)).toContainText(
+    editSet.note,
+  );
+});
 
-  // １セット目を記録する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('24.52');
-  await page.getByRole('spinbutton', { name: '値' }).fill('10');
-  await page.getByRole('button', { name: '追加する' }).click();
+test('トレーニングセットを削除できる', async ({ trainingRecordPage }) => {
+  // トレーニングセット登録中に削除すると挙動がおかしくなるため toHaveCount で登録が完了するのをまつ
+  // TODO: toHaveCount を使わない方法を探す
+  await expect(trainingRecordPage.trainingSetItems).toHaveCount(4);
 
-  // ２セット目を記録する
-  await page.getByRole('spinbutton', { name: '負荷' }).fill('26.32');
-  await page.getByRole('spinbutton', { name: '値' }).fill('22');
-  await page.getByRole('textbox', { name: '備考' }).fill('追い込み');
-  await expect(page.getByRole('button', { name: '追加する' })).toBeEnabled();
-  await page.getByRole('button', { name: '追加する' }).click();
-  await expect(page.getByRole('button', { name: '追加する' })).toBeEnabled();
-
-  // 削除ボタンをクリックする
-  const firstSet = page
-    .getByRole('list', { name: 'トレーニングセット' })
-    .getByRole('listitem')
-    .first();
-  await firstSet.getByRole('button', { name: '削除' }).click();
-  await page
-    .getByRole('button', { name: 'トレーニングセットを削除する' })
-    .click();
-
-  await expect(firstSet).toContainText('26.32');
-  await expect(firstSet).toContainText('22');
-  await expect(firstSet).toContainText('追い込み');
+  await trainingRecordPage.removeTrainingSet(1);
+  await expect(trainingRecordPage.trainingSetItems.nth(1)).not.toContainText(
+    `${sets[1].load}`,
+  );
 });


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

treco-web/e2e/pages/training-record.page.ts:
- `TrainingRecordPage`クラスに新しいメソッドが追加されました。
- `addTrainingSet`メソッドは、トレーニングセットを追加するためのものです。
- `editTrainingSet`メソッドは指定したインデックスのトレーニングセットを編集するためのものです。
- `goToNewCategoryEvent`メソッドは、新しいカテゴリーとイベントに移動するためのものです。
- これらの変更は、外部インターフェースやコードの動作に影響を与える可能性があります。

treco-web/e2e/training-record.test.ts:
- テストコードがリファクタリングされました。
- `@playwright/test`パッケージから`expect`と`test`がインポートされるように変更されました。
- テストケースごとにページオブジェクトを作成する代わりに、共有のページオブジェクトを作成するために`base.extend`が使用されるように変更されました。
- テストケース内の各アサーションが、新しいページオブジェクトのメソッドを使用するように変更されました。
- これらの変更により、テストコードの可読性と保守性が向上しました。

リリースノート：
- `TrainingRecordPage`クラスに新しいメソッドが追加されました。これにより、トレーニングセットの追加や編集、新しいカテゴリーとイベントへの移動が可能になります。
- テストコードがリファクタリングされ、可読性と保守性が向上しました。`expect`と`test`のインポート方法が変更され、共有のページオブジェクトが使用されるようになりました。また、各アサーションも新しいページオブジェクトのメソッドを使用するように変更されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->