### PR TITLE
トレーニー作成時にドメインイベントを使うように変更

### DIFF
--- a/treco-web/prisma/migrations/20231118201135_auth_trainee_relation_change/migration.sql
+++ b/treco-web/prisma/migrations/20231118201135_auth_trainee_relation_change/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `traineeId` on the `AuthUser` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[authUserId]` on the table `Trainee` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `authUserId` to the `Trainee` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "AuthUser" DROP CONSTRAINT "AuthUser_traineeId_fkey";
+
+-- DropIndex
+DROP INDEX "AuthUser_traineeId_key";
+
+-- AlterTable
+ALTER TABLE "AuthUser" DROP COLUMN "traineeId";
+
+-- AlterTable
+ALTER TABLE "Trainee" ADD COLUMN     "authUserId" UUID NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Trainee_authUserId_key" ON "Trainee"("authUserId");
+
+-- AddForeignKey
+ALTER TABLE "Trainee" ADD CONSTRAINT "Trainee_authUserId_fkey" FOREIGN KEY ("authUserId") REFERENCES "AuthUser"("authUserId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/treco-web/prisma/schema.prisma
+++ b/treco-web/prisma/schema.prisma
@@ -13,15 +13,15 @@ datasource db {
 
 model AuthUser {
   authUserId String @id @db.Uuid
-  traineeId String @unique @db.Uuid
   sub String @unique @db.VarChar(255)
   email String @unique @db.VarChar(1024)
 
-  trainee   Trainee @relation(fields: [traineeId], references: [traineeId])
+  trainee Trainee?
 }
 
 model Trainee {
   traineeId String @id @db.Uuid
+  authUserId String @unique @db.Uuid
 
   name   String
 
@@ -32,7 +32,7 @@ model Trainee {
   trainingEvents     TrainingEvent[]
   trainingRecords    TrainingRecord[]
 
-  authUser AuthUser?
+  authUser AuthUser @relation(fields: [authUserId], references: [authUserId])
 }
 
 model TrainingCategory {

--- a/treco-web/prisma/seed.ts
+++ b/treco-web/prisma/seed.ts
@@ -16,20 +16,18 @@ const prisma = new PrismaClient();
     await prisma.trainingRecord.deleteMany();
     await prisma.trainingEvent.deleteMany();
     await prisma.trainingCategory.deleteMany();
-    await prisma.authUser.deleteMany();
     await prisma.trainee.deleteMany();
-
-    await prisma.trainee.createMany({
-      data: traineeFixtures,
-    });
+    await prisma.authUser.deleteMany();
 
     await prisma.authUser.createMany({
-      data: traineeFixtures.map((trainee, index) => {
-        return {
-          traineeId: trainee.traineeId,
-          ...authUserFixtures[index],
-        };
-      }),
+      data: authUserFixtures,
+    });
+
+    await prisma.trainee.createMany({
+      data: authUserFixtures.map(({ authUserId }, index) => ({
+        ...traineeFixtures[index],
+        authUserId,
+      })),
     });
 
     await Promise.all(

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_actions/create-training-event.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_actions/create-training-event.action.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { DomainEventPublisher } from '@/domains/lib/domain-event-publisher';
 import { TraineePrismaRepository } from '@/domains/trainee/infrastructures/prisma.repository';
 import { TrainingCategoryPrismaRepository } from '@/domains/training-category/infrastructures/prisma.repository';
 import { TrainingEventPrismaRepository } from '@/domains/training-event/infrastructures/prisma.repository';
@@ -20,8 +21,8 @@ export async function createTrainingEventAction(
   const traineeId = await getSignedInTraineeId();
 
   await new TrainingEventCreateUsecase(
-    new TraineePrismaRepository(),
-    new TrainingCategoryPrismaRepository(),
+    new TraineePrismaRepository(new DomainEventPublisher()),
+    new TrainingCategoryPrismaRepository(new DomainEventPublisher()),
     new TrainingEventPrismaRepository(),
   ).execute({
     traineeId,

--- a/treco-web/src/app/(header)/(auth)/home/categories/_actions/create-training-category.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/categories/_actions/create-training-category.action.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { DomainEventPublisher } from '@/domains/lib/domain-event-publisher';
 import { TraineePrismaRepository } from '@/domains/trainee/infrastructures/prisma.repository';
 import { TrainingCategoryPrismaRepository } from '@/domains/training-category/infrastructures/prisma.repository';
 import { TrainingCategoryCreateUsecase } from '@/domains/training-category/usecases/create.usecase';
@@ -15,8 +16,8 @@ export async function createTrainingCategoryAction(props: Props) {
   const traineeId = await getSignedInTraineeId();
 
   await new TrainingCategoryCreateUsecase(
-    new TraineePrismaRepository(),
-    new TrainingCategoryPrismaRepository(),
+    new TraineePrismaRepository(new DomainEventPublisher()),
+    new TrainingCategoryPrismaRepository(new DomainEventPublisher()),
   ).execute({
     traineeId,
     ...props,

--- a/treco-web/src/app/(header)/(auth)/home/categories/_actions/delete-training-category.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/categories/_actions/delete-training-category.action.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { DomainEventPublisher } from '@/domains/lib/domain-event-publisher';
 import { TrainingCategoryPrismaRepository } from '@/domains/training-category/infrastructures/prisma.repository';
 import { TrainingCategoryDeleteUsecase } from '@/domains/training-category/usecases/delete.usecase';
 import { revalidatePath } from 'next/cache';
@@ -10,7 +11,7 @@ type Props = {
 
 export async function deleteTrainingCategoryAction(props: Props) {
   await new TrainingCategoryDeleteUsecase(
-    new TrainingCategoryPrismaRepository(),
+    new TrainingCategoryPrismaRepository(new DomainEventPublisher()),
   ).execute(props);
 
   revalidatePath('(header)/(auth)/home/categories');

--- a/treco-web/src/app/(header)/(auth)/home/categories/_actions/edit-training-category.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/categories/_actions/edit-training-category.action.ts
@@ -1,4 +1,5 @@
 'use server';
+import { DomainEventPublisher } from '@/domains/lib/domain-event-publisher';
 import { TrainingCategoryPrismaRepository } from '@/domains/training-category/infrastructures/prisma.repository';
 import { TrainingCategoryEditUsecase } from '@/domains/training-category/usecases/edit.usecase';
 import { revalidatePath } from 'next/cache';
@@ -11,7 +12,7 @@ type Props = {
 
 export async function editTrainingCategoryAction(props: Props) {
   await new TrainingCategoryEditUsecase(
-    new TrainingCategoryPrismaRepository(),
+    new TrainingCategoryPrismaRepository(new DomainEventPublisher()),
   ).execute(props);
 
   revalidatePath('(header)/(auth)/home/categories');

--- a/treco-web/src/domains/lib/domain-event-listener.ts
+++ b/treco-web/src/domains/lib/domain-event-listener.ts
@@ -1,0 +1,22 @@
+import EventEmitter from 'events';
+
+import { DomainEvent } from './domain-event';
+
+export class DomainEventListener {
+  static emitter = new EventEmitter();
+
+  static emit(eventName: string, event: DomainEvent) {
+    this.emitter.emit(eventName, event);
+  }
+
+  static on<T extends DomainEvent>(
+    eventName: string,
+    callback: (event: T) => Promise<void>,
+  ) {
+    this.emitter.on(eventName, callback);
+  }
+
+  static {
+    this.emitter.setMaxListeners(0);
+  }
+}

--- a/treco-web/src/domains/lib/domain-event-publisher.ts
+++ b/treco-web/src/domains/lib/domain-event-publisher.ts
@@ -1,0 +1,8 @@
+import { DomainEvent } from './domain-event';
+import { DomainEventListener } from './domain-event-listener';
+
+export class DomainEventPublisher {
+  publish(event: DomainEvent) {
+    DomainEventListener.emit(event.name, event);
+  }
+}

--- a/treco-web/src/domains/lib/domain-event.ts
+++ b/treco-web/src/domains/lib/domain-event.ts
@@ -1,0 +1,7 @@
+import EventEmitter from 'events';
+
+export const eventEmitter = new EventEmitter();
+
+export interface DomainEvent {
+  name: string;
+}

--- a/treco-web/src/domains/trainee/infrastructures/prisma.repository.ts
+++ b/treco-web/src/domains/trainee/infrastructures/prisma.repository.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { Trainee } from '../models/trainee';
 import { TraineeRepository } from '../usecases/repository';
 
-export class TraineePrismaRepository implements TraineeRepository {
+export class TraineePrismaRepository extends TraineeRepository {
   async findOneById(traineeId: string) {
     const trainee = await prisma.trainee.findUnique({
       where: {
@@ -12,5 +12,21 @@ export class TraineePrismaRepository implements TraineeRepository {
     });
 
     return trainee ? Trainee.fromDto(trainee) : null;
+  }
+
+  protected async saveImpl(trainee: Trainee): Promise<void> {
+    const dto = trainee.toDto();
+
+    await prisma.trainee.upsert({
+      create: {
+        ...dto,
+      },
+      update: {
+        name: dto.name,
+      },
+      where: {
+        traineeId: dto.traineeId,
+      },
+    });
   }
 }

--- a/treco-web/src/domains/trainee/models/trainee-create-event.ts
+++ b/treco-web/src/domains/trainee/models/trainee-create-event.ts
@@ -1,0 +1,14 @@
+import { DomainEvent } from '@/domains/lib/domain-event';
+
+type Props = {
+  traineeId: string;
+};
+
+export class TraineeCreateEvent implements DomainEvent {
+  name = 'TraineeCreateEvent';
+  traineeId: string;
+
+  constructor({ traineeId }: Props) {
+    this.traineeId = traineeId;
+  }
+}

--- a/treco-web/src/domains/trainee/models/trainee.ts
+++ b/treco-web/src/domains/trainee/models/trainee.ts
@@ -1,11 +1,51 @@
+import { DomainEvent } from '@/domains/lib/domain-event';
+import { generateId } from '@/lib/id';
+
+import { TraineeCreateEvent } from './trainee-create-event';
+
 export type TraineeDto = {
+  authUserId: string;
+  name: string;
   traineeId: string;
 };
 
+type TraineeCreateProps = Omit<TraineeDto, 'traineeId'>;
+
 export class Trainee {
+  private domainEvents: DomainEvent[] = [];
+
   private constructor(private dto: TraineeDto) {}
+
+  static create(props: TraineeCreateProps) {
+    const traineeId = generateId();
+
+    const trainee = new Trainee({
+      authUserId: props.authUserId,
+      name: props.name,
+      traineeId,
+    });
+    trainee.addDomainEvent(new TraineeCreateEvent({ traineeId }));
+
+    return trainee;
+  }
 
   static fromDto(dto: TraineeDto) {
     return new Trainee(dto);
+  }
+
+  addDomainEvent(event: DomainEvent) {
+    this.domainEvents.push(event);
+  }
+
+  clearDomainEvents() {
+    this.domainEvents = [];
+  }
+
+  getDomainEvents() {
+    return this.domainEvents;
+  }
+
+  toDto() {
+    return { ...this.dto };
   }
 }

--- a/treco-web/src/domains/trainee/usecases/create.usecase.ts
+++ b/treco-web/src/domains/trainee/usecases/create.usecase.ts
@@ -1,0 +1,15 @@
+import { Trainee, TraineeDto } from '../models/trainee';
+import { TraineeRepository } from './repository';
+
+type ExecuteProps = Parameters<(typeof Trainee)['create']>[0];
+
+export class TraineeCreateUsecase {
+  constructor(private readonly traineeRepository: TraineeRepository) {}
+
+  async execute(props: ExecuteProps): Promise<TraineeDto> {
+    const trainee = Trainee.create(props);
+    await this.traineeRepository.save(trainee);
+
+    return trainee.toDto();
+  }
+}

--- a/treco-web/src/domains/trainee/usecases/repository.ts
+++ b/treco-web/src/domains/trainee/usecases/repository.ts
@@ -1,5 +1,23 @@
+import { DomainEventPublisher } from '@/domains/lib/domain-event-publisher';
+
 import { Trainee } from '../models/trainee';
 
-export interface TraineeRepository {
-  findOneById(traineeId: string): Promise<Trainee | null>;
+export abstract class TraineeRepository {
+  constructor(private domainEventPublisher: DomainEventPublisher) {}
+
+  private publishDomainEvent(trainee: Trainee) {
+    trainee
+      .getDomainEvents()
+      .map(async (event) => this.domainEventPublisher.publish(event));
+    trainee.clearDomainEvents();
+  }
+
+  async save(trainee: Trainee): Promise<void> {
+    await this.saveImpl(trainee);
+    this.publishDomainEvent(trainee);
+  }
+
+  abstract findOneById(traineeId: string): Promise<Trainee | null>;
+
+  protected abstract saveImpl(trainee: Trainee): Promise<void>;
 }

--- a/treco-web/src/domains/training-category/infrastructures/prisma.repository.ts
+++ b/treco-web/src/domains/training-category/infrastructures/prisma.repository.ts
@@ -3,9 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { TrainingCategory } from '../models/training-category';
 import { TrainingCategoryRepository } from '../usecases/repository';
 
-export class TrainingCategoryPrismaRepository
-  implements TrainingCategoryRepository
-{
+export class TrainingCategoryPrismaRepository extends TrainingCategoryRepository {
   async delete(trainingCategoryId: string): Promise<void> {
     await prisma.trainingCategory.delete({
       where: {
@@ -39,7 +37,7 @@ export class TrainingCategoryPrismaRepository
     return TrainingCategory.fromDto(trainingCategory);
   }
 
-  async save(trainingCategory: TrainingCategory): Promise<void> {
+  async saveImpl(trainingCategory: TrainingCategory): Promise<void> {
     const dto = trainingCategory.toDto();
     await prisma.trainingCategory.upsert({
       create: dto,

--- a/treco-web/src/domains/training-category/models/training-category-create-default.ts
+++ b/treco-web/src/domains/training-category/models/training-category-create-default.ts
@@ -1,0 +1,18 @@
+import { DomainEvent } from '@/domains/lib/domain-event';
+
+export class TrainingCategoryCreateDefaultEvent implements DomainEvent {
+  readonly name = 'TrainingCategoryCreateDefaultEvent';
+  readonly traineeId: string;
+  readonly trainingCategoryId: string;
+  readonly trainingCategoryName: string;
+
+  constructor(params: {
+    traineeId: string;
+    trainingCategoryId: string;
+    trainingCategoryName: string;
+  }) {
+    this.traineeId = params.traineeId;
+    this.trainingCategoryId = params.trainingCategoryId;
+    this.trainingCategoryName = params.trainingCategoryName;
+  }
+}

--- a/treco-web/src/domains/training-category/usecases/event-listener.ts
+++ b/treco-web/src/domains/training-category/usecases/event-listener.ts
@@ -1,0 +1,24 @@
+import { DomainEventListener } from '@/domains/lib/domain-event-listener';
+import { TraineeCreateEvent } from '@/domains/trainee/models/trainee-create-event';
+
+import { TrainingCategory } from '../models/training-category';
+import { TrainingCategoryRepository } from './repository';
+
+export class TrainingCategoryEventListener {
+  constructor(private repository: TrainingCategoryRepository) {}
+
+  private async callback(event: TraineeCreateEvent) {
+    await Promise.all(
+      TrainingCategory.createDefaultCategories({
+        traineeId: event.traineeId,
+      }).map((trainingCategory) => this.repository.save(trainingCategory)),
+    );
+  }
+
+  listen() {
+    DomainEventListener.on(
+      'TraineeCreateEvent',
+      async (event: TraineeCreateEvent) => await this.callback(event),
+    );
+  }
+}

--- a/treco-web/src/domains/training-category/usecases/repository.ts
+++ b/treco-web/src/domains/training-category/usecases/repository.ts
@@ -1,11 +1,27 @@
+import { DomainEventPublisher } from '@/domains/lib/domain-event-publisher';
+
 import { TrainingCategory } from '../models/training-category';
 
-export interface TrainingCategoryRepository {
-  delete(trainingCategoryId: string): Promise<void>;
-  findById(trainingCategoryId: string): Promise<TrainingCategory>;
-  findOneByOrder(props: {
+export abstract class TrainingCategoryRepository {
+  constructor(private domainEventPublisher: DomainEventPublisher) {}
+
+  private publishDomainEvent(trainingCategory: TrainingCategory) {
+    trainingCategory
+      .getDomainEvents()
+      .map((event) => this.domainEventPublisher.publish(event));
+    trainingCategory.clearDomainEvents();
+  }
+  async save(trainingCategory: TrainingCategory): Promise<void> {
+    await this.saveImpl(trainingCategory);
+    this.publishDomainEvent(trainingCategory);
+  }
+  abstract delete(trainingCategoryId: string): Promise<void>;
+  abstract findById(trainingCategoryId: string): Promise<TrainingCategory>;
+
+  abstract findOneByOrder(props: {
     order: 'last';
     traineeId: string;
   }): Promise<TrainingCategory | null>;
-  save(trainingCategory: TrainingCategory): Promise<void>;
+
+  abstract saveImpl(trainingCategory: TrainingCategory): Promise<void>;
 }

--- a/treco-web/src/domains/training-event/lib/default-events.ts
+++ b/treco-web/src/domains/training-event/lib/default-events.ts
@@ -150,6 +150,25 @@ const defaultEvents = [
     valueUnit: '回 ',
   },
   {
+    categoryName: '腕',
+    loadUnit: 'kg',
+    name: 'ダンベルカール',
+    valueUnit: '回 ',
+  },
+  {
+    categoryName: '腕',
+    loadUnit: 'kg',
+    name: 'ダンベルフレンチプレス',
+    valueUnit: '回 ',
+  },
+  {
+    categoryName: '腕',
+    loadUnit: 'kg',
+    name: 'トライセプスキックバック',
+    valueUnit: '回 ',
+  },
+
+  {
     categoryName: '背中',
     loadUnit: 'kg',
     name: 'デッドリフト',

--- a/treco-web/src/domains/training-event/models/training-category-create-default.ts
+++ b/treco-web/src/domains/training-event/models/training-category-create-default.ts
@@ -1,0 +1,18 @@
+import { DomainEvent } from '@/domains/lib/domain-event';
+
+export class TrainingCategoryCreateDefaultEvent implements DomainEvent {
+  readonly name = 'TrainingCategoryCreateDefaultEvent';
+  readonly traineeId: string;
+  readonly trainingCategoryId: string;
+  readonly trainingCategoryName: string;
+
+  constructor(params: {
+    traineeId: string;
+    trainingCategoryId: string;
+    trainingCategoryName: string;
+  }) {
+    this.traineeId = params.traineeId;
+    this.trainingCategoryId = params.trainingCategoryId;
+    this.trainingCategoryName = params.trainingCategoryName;
+  }
+}

--- a/treco-web/src/domains/training-event/models/training-event.ts
+++ b/treco-web/src/domains/training-event/models/training-event.ts
@@ -1,5 +1,7 @@
 import { generateId } from '@/lib/id';
 
+import { getDefaultEvents } from '../lib/default-events';
+
 export type TrainingEventDto = {
   loadUnit: string;
   name: string;
@@ -27,6 +29,25 @@ export class TrainingEvent {
     });
   }
 
+  static createDefaultTrainingEvents(props: {
+    traineeId: string;
+    trainingCategoryId: string;
+    trainingCategoryName: string;
+  }) {
+    return getDefaultEvents(props.trainingCategoryName).map(
+      (trainingCategoryDto, order) =>
+        new TrainingEvent({
+          loadUnit: trainingCategoryDto.loadUnit,
+          name: trainingCategoryDto.name,
+          order,
+          traineeId: props.traineeId,
+          trainingCategoryId: props.trainingCategoryId,
+          trainingEventId: generateId(),
+          valueUnit: trainingCategoryDto.valueUnit,
+        }),
+    );
+  }
+
   static fromDto(dto: TrainingEventDto) {
     return new TrainingEvent(dto);
   }
@@ -34,7 +55,6 @@ export class TrainingEvent {
   changeLoadUnit(loadUnit: string) {
     this.dto.loadUnit = loadUnit;
   }
-
   changeName(name: string) {
     this.dto.name = name;
   }

--- a/treco-web/src/domains/training-event/usecases/event-listener.ts
+++ b/treco-web/src/domains/training-event/usecases/event-listener.ts
@@ -1,0 +1,27 @@
+import { DomainEventListener } from '@/domains/lib/domain-event-listener';
+
+import { TrainingCategoryCreateDefaultEvent } from '../models/training-category-create-default';
+import { TrainingEvent } from '../models/training-event';
+import { TrainingEventRepository } from './repository';
+
+export class TrainingEventEventListener {
+  constructor(private repository: TrainingEventRepository) {}
+
+  private async callback(event: TrainingCategoryCreateDefaultEvent) {
+    await Promise.all(
+      TrainingEvent.createDefaultTrainingEvents({
+        traineeId: event.traineeId,
+        trainingCategoryId: event.trainingCategoryId,
+        trainingCategoryName: event.trainingCategoryName,
+      }).map((trainingCategory) => this.repository.save(trainingCategory)),
+    );
+  }
+
+  listen() {
+    DomainEventListener.on(
+      'TrainingCategoryCreateDefaultEvent',
+      async (event: TrainingCategoryCreateDefaultEvent) =>
+        await this.callback(event),
+    );
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です。

treco-web/src/domains/training-event/usecases/event-listener.ts:
- トレーニー作成時にドメインイベントを使用するようにコードが変更されました。
- `TrainingEventEventListener`クラスが追加され、`TrainingCategoryCreateDefaultEvent`イベントを受け取り、関連するトレーニングイベントを作成して保存するコールバック関数が追加されました。
- `listen()`メソッドは`TrainingCategoryCreateDefaultEvent`イベントのリスナーとして登録されます。
- 外部インターフェースやコードの振る舞いに影響する変更はありません。

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_actions/create-training-event.action.ts:
- トレーニー作成時にドメインイベントを使用するようにコードが変更されました。
- `TraineePrismaRepository`と`TrainingCategoryPrismaRepository`のコンストラクタに`DomainEventPublisher`が渡されるようになりました。
- これにより、トレーニー作成時にドメインイベントが発行されるようになります。
- 外部インターフェースやコードの振る舞いに影響を与える可能性のある変更はありません。

treco-web/src/app/(header)/(auth)/home/categories/_actions/create-training-category.action.ts:
- トレーニー作成時にドメインイベントを使用するようにコードが変更されました。
- `createTrainingCategoryAction`関数内での`TraineePrismaRepository`と`TrainingCategoryPrismaRepository`のインスタンス化時に、`DomainEventPublisher`を引数として渡すようになりました。
- これにより、トレーニー作成時にドメインイベントが発行されるようになります。
- 外部インターフェースやコードの振る舞いに影響を与える可能性のある変更はありません。

treco-web/src/app/(header)/(auth)/home/categories/_actions/delete-training-category.action.ts:
- トレーニングカテゴリを削除する際にドメインイベントを使用するように変更されました。
- `TrainingCategoryPrismaRepository`のコンストラクタに`DomainEventPublisher`が渡されるようになりました。
- これにより、トレーニングカテゴリの削除時にドメインイベントが発行されるようになります。
- 外部インターフェースやコードの振る舞いに影響を与える可能性のある変更はありません。

treco-web/src/app/(header)/(auth)/home/categories/_actions/edit-training-category.action.ts:
- このファイルに関する変更内容は提供されていません。

リリースノート:
- トレーニー作成時やトレーニングカテゴリの作成・削除時にドメインイベントが使用されるようになりました。
- 外部インターフェースやコードの振る舞いには影響がありません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->