### PR TITLE
ページタイトル設定

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/account/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/account/page.tsx
@@ -1,4 +1,9 @@
+import { Metadata } from 'next';
 import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'アカウント設定',
+};
 
 export default function AccountPage() {
   return (

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/[eventId]/records/[recordId]/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/[eventId]/records/[recordId]/page.tsx
@@ -3,8 +3,10 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { PrismaTrainingRecordQuery } from '@/domains/training-record/infrastructures/prisma.query';
 import { TrainingRecordQueryOneForTrainingRecordEditUsecase } from '@/domains/training-record/usecases/query-one-for-training-record-edit.usecase';
+import { createTZDate } from '@/lib/date';
 import { getSignedInTraineeId } from '@/lib/trainee';
 import clsx from 'clsx';
+import React from 'react';
 
 import { addSetAction, editSetAction } from './actions';
 import { CancelButton } from './cancel-button';
@@ -20,6 +22,8 @@ async function queryTrainingRecordEdit(trainingRecordId: string) {
   return await queryUsecase.execute(trainingRecordId);
 }
 
+const cachedQueryTrainingRecordEdit = React.cache(queryTrainingRecordEdit);
+
 type Props = {
   params: {
     categoryId: string;
@@ -27,9 +31,24 @@ type Props = {
     recordId: string;
   };
   searchParams: {
+    date: string;
     edit?: string;
   };
 };
+
+export async function generateMetadata({ params, searchParams }: Props) {
+  const selectDate = createTZDate(searchParams['date']);
+  const { trainingEvent } = await cachedQueryTrainingRecordEdit(
+    params.recordId,
+  );
+
+  searchParams;
+  return {
+    title: `${trainingEvent.name}の記録（${selectDate.format(
+      'YYYY月MM月DD日',
+    )}）`,
+  };
+}
 
 export default async function TrainingRecordEditPage({
   params,

--- a/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
@@ -4,11 +4,15 @@ import { PrismaTrainingCategoryQuery } from '@/domains/training-category/infrast
 import { TrainingCategoryQueryByTraineeIdUsecase } from '@/domains/training-category/usecases/query-by-trainee-id.usecase';
 import { createTZDate } from '@/lib/date';
 import { getSignedInTraineeId } from '@/lib/trainee';
+import { Metadata } from 'next';
 import Link from 'next/link';
 
 import { CategoryDelete } from './_components/category-delete';
 import { CategoryEdit } from './_components/category-edit';
 
+export const metadata: Metadata = {
+  title: 'トレーニングカテゴリー一覧',
+};
 async function queryCategories(props: { traineeId: string }) {
   const queryByTraineeIdUsecase = new TrainingCategoryQueryByTraineeIdUsecase(
     new PrismaTrainingCategoryQuery(),

--- a/treco-web/src/app/(header)/(auth)/home/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/page.tsx
@@ -4,9 +4,14 @@ import { PrismaTrainingRecordQuery } from '@/domains/training-record/infrastruct
 import { TrainingRecordQueryListForHomeUsecase } from '@/domains/training-record/usecases/query-list-for-home.usecase';
 import { createTZDate } from '@/lib/date';
 import { getSignedInTraineeId } from '@/lib/trainee';
+import { Metadata } from 'next';
 import { Suspense } from 'react';
 
 import { Calendar } from './_component/calendar';
+
+export const metadata: Metadata = {
+  title: 'ホーム',
+};
 
 async function queryTrainingRecord(date: Date) {
   const traineeId = await getSignedInTraineeId();

--- a/treco-web/src/app/(header)/policies/privacy-policy/page.tsx
+++ b/treco-web/src/app/(header)/policies/privacy-policy/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { PolicyContainer } from '../PolicyContainer';
 
 export const metadata: Metadata = {
-  title: 'プライバシーポリシー | TRECo',
+  title: 'プライバシーポリシー',
 };
 
 const text = `根本将治（以下「当社」といいます。）は、当社がTRECo（以下「本サービス」といいます。）を提供するにあたり、ご利用される皆様（以下「利用者」といいます。）の個人に関する情報（以下「個人情報」といいます。）を取得します。

--- a/treco-web/src/app/(header)/policies/term-of-service/page.tsx
+++ b/treco-web/src/app/(header)/policies/term-of-service/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { PolicyContainer } from '../PolicyContainer';
 
 export const metadata: Metadata = {
-  title: '利用規約 | TRECo',
+  title: '利用規約',
 };
 
 const text = `本規約は、根本将治（以下「当社」といいます。）が提供する「TRECo」（以下「本サービス」といいます。）を利用される際に適用されます。ご利用にあたっては、本規約をお読みいただき、内容をご承諾の上でご利用ください。

--- a/treco-web/src/app/(public)/page.tsx
+++ b/treco-web/src/app/(public)/page.tsx
@@ -7,7 +7,7 @@ import { LoginButtonList } from '../login-button-list';
 import QRCode from './qr.png';
 import SplashImage from './splash.svg';
 
-export default async function Home() {
+export default async function Top() {
   if (await isAuthenticated()) {
     redirect('/home');
   }

--- a/treco-web/src/app/layout.tsx
+++ b/treco-web/src/app/layout.tsx
@@ -14,7 +14,10 @@ const baseFont = M_PLUS_Rounded_1c({
 export const metadata: Metadata = {
   description:
     'トレーニングをもっと楽しくするシンプルなトレーニング記録サービス',
-  title: 'TRECo - BESIDE YOUR WORKOUT',
+  title: {
+    default: 'TRECo -BESIDE YOUR WORKOUT-',
+    template: '%s | TRECo',
+  },
   viewport: {
     initialScale: 1,
     maximumScale: 1,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

リリースノート:

- treco-web/src/app/(header)/(auth)/home/account/page.tsx:
  - `next`パッケージの`Metadata`をインポートし、`metadata`オブジェクトを追加しました。
  - `metadata`オブジェクトには、ページのタイトルが設定されています。
  - `AccountPage`関数コンポーネント内で、`title`プロパティを使用してページのタイトルを表示するための変更が行われました。
  - アカウント設定ページのタイトルが正しく設定されるようになります。

- treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/[eventId]/records/[recordId]/page.tsx:
  - `TrainingRecordEditPage`コンポーネントに`generateMetadata`関数が追加されました。
  - `generateMetadata`関数は、メタデータオブジェクトを生成するために使用されます。
  - `generateMetadata`関数は、`params`と`searchParams`を受け取り、指定された日付とトレーニングイベントの名前を含むタイトルを返します。
  - 外部インターフェースやコードの動作に影響を与える可能性があります。

- treco-web/src/app/(header)/(auth)/home/categories/page.tsx:
  - `metadata`という新しい変数が追加されました。
  - `metadata`は`next`パッケージの`Metadata`型であり、ページのタイトルを設定するために使用されます。
  - トレーニングカテゴリー一覧ページのタイトルが設定されるようになります。
  - 外部インターフェースやコードの動作に影響を与える可能性のある変更はありません。

- treco-web/src/app/(header)/(auth)/home/page.tsx:
  - `metadata`という新しい変数が追加されました。
  - Next.jsのメタデータオブジェクトであり、ページのタイトルを設定するために使用されます。
  - `title`プロパティが追加され、値は「ホーム」となっています。
  - ページのタイトルを設定するための機能改善です。
  - 外部インターフェースやコードの動作に影響を与える可能性は低いです。

- treco-web/src/app/(header)/policies/privacy-policy/page.tsx:
  - ページのタイトルを変更するための変更です。
  - `metadata`オブジェクトの`title`プロパティが変更され、新しいタイトルが設定されました。
  - プライバシーポリシーページのタイトルが「プライバシーポリシー」に変更されます。
  - 関数やグローバルデータ構造、変数に対する変更はなく、外部インターフェースやコードの動作に影響を与える変更もありません。

- treco-web/src/app/(header)/policies/term-of-service/page.tsx:
  - ページのタイトル設定に関する変更です。
  - `metadata`オブジェクトの`title`プロパティが変更され、"利用規約 | TRECo"から"利用規約"に変更されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->