### PR TITLE
カレンダーの今日としてハイライトする日付のズレ修正

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/_component/calendar-month.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/_component/calendar-month.tsx
@@ -86,7 +86,7 @@ export function CalendarMonth({
       {days.map((day) => {
         return (
           <Day
-            active={utcDate().isSame(day, 'day')}
+            active={utcDate().tz('Asia/Tokyo').isSame(day, 'day')}
             date={day.toDate()}
             highlight={day.isSame(selectDate, 'day')}
             key={day.toISOString()}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

ファイルの変更内容の要約は以下の通りです：

```
treco-web/src/app/(header)/(auth)/home/_component/calendar-month.tsx: この変更は、カレンダーの日付をハイライトするためのズレを修正しています。具体的には、`CalendarMonth`コンポーネント内の`Day`コンポーネントの`active`プロパティの値を修正しています。修正前は、現在の日付をUTCで比較していましたが、修正後は日本のタイムゾーン（Asia/Tokyo）で比較するようになっています。これにより、カレンダー上で正確な今日の日付がハイライトされるようになります。この変更は、外部インターフェースやコードの動作に影響を与える可能性があるため、注意が必要です。
```

リリースノート：
- カレンダーの日付をハイライトするためのズレを修正しました。
- `CalendarMonth`コンポーネント内の`Day`コンポーネントの`active`プロパティの値を修正しました。
- 修正前は、現在の日付をUTCで比較していましたが、修正後は日本のタイムゾーン（Asia/Tokyo）で比較するようになりました。
- これにより、カレンダー上で正確な今日の日付がハイライトされるようになります。
- この変更は、外部インターフェースやコードの動作に影響を与える可能性があるため、注意が必要です。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->