### PR TITLE
Renovate 自動マージ

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,18 +3,20 @@
   extends: ["config:recommended"],
   timezone: "Asia/Tokyo",
   schedule: ["every weekend"],
+  labels: ["renovate"],
   packageRules: [
     {
-      major: {
-        stabilityDays: 7,
-      },
-      minor: {
-        stabilityDays: 3,
-      },
-      patch: {
-        stabilityDays: 2,
-        automerge: true,
-      },
+      matchUpdateTypes: ["minor", "patch", "pin"],
+      matchDepTypes: ["devDependencies"],
+      groupName: "メジャー以外の devDependencies の自動マージ",
+      addLabels: ["devDependencies", "minor", "patch", "pin", "automerge"],
+      automerge: true,
+    },
+    {
+      matchUpdateTypes: ["patch", "pin"],
+      groupName: "patch, pin の自動マージ",
+      addLabels: ["allDependencies", "patch", "pin", "automerge"],
+      automerge: true,
     },
   ],
 }

--- a/treco-web/src/app/(header)/(auth)/home/_component/calendar-month.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/_component/calendar-month.tsx
@@ -58,7 +58,10 @@ export function CalendarMonth({
   const trainingMarks = data
     ? data.reduce(
         (group, record) => {
-          const date = utcDate(record.trainingDate).toISOString();
+          const date = utcDate(record.trainingDate)
+            .tz('Asia/Tokyo')
+            .startOf('day')
+            .toISOString();
           if (!group[date]) {
             group[date] = {};
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容に関するリリースノートです。

-.github/renovate.json5: Renovateの設定が更新されました。新しい設定では、特定の条件に基づいてdevDependenciesとしてマークされたパッケージの自動マージが有効になります。メジャーアップデート以外のバージョンアップ（マイナーアップデート、パッチアップデート、ピン留め）は、安定期間を経過した後に自動的にマージされます。また、パッチアップデートとピン留めの場合も同様に自動マージが行われます。これにより、開発者は手動でのマージ作業を省くことができます。

以上が変更内容の要点です。詳細な情報や他の変更セットについては、プルリクエストをご確認ください。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->