### PR TITLE
カテゴリー整理

### DIFF
--- a/treco-web/e2e/pages/training-category.page.ts
+++ b/treco-web/e2e/pages/training-category.page.ts
@@ -6,7 +6,7 @@ export class TrainingCategoryPage {
   constructor(private page: Page) {
     this.trainingCategoryItems = page
       .getByRole('list', {
-        name: 'トレーニングカテゴリーリスト',
+        name: 'トレーニングカテゴリー',
       })
       .getByRole('listitem');
   }

--- a/treco-web/e2e/pages/training-event.page.ts
+++ b/treco-web/e2e/pages/training-event.page.ts
@@ -58,7 +58,7 @@ export class TrainingEventPage {
       .click();
     await this.page.getByRole('textbox', { name: '名前' }).fill(categoryName);
     await this.page.getByRole('button', { name: '保存する' }).click();
-    await this.page.getByRole('listitem', { name: categoryName }).click();
+    await this.page.getByRole('link', { name: categoryName }).click();
   }
 
   async inputTrainingEvent({

--- a/treco-web/e2e/pages/training-record.page.ts
+++ b/treco-web/e2e/pages/training-record.page.ts
@@ -49,7 +49,7 @@ export class TrainingRecordPage {
       .click();
     await this.page.getByRole('textbox', { name: '名前' }).fill(categoryName);
     await this.page.getByRole('button', { name: '保存する' }).click();
-    await this.page.getByRole('listitem', { name: categoryName }).click();
+    await this.page.getByRole('link', { name: categoryName }).click();
 
     await this.page
       .getByRole('button', { name: 'トレーニング種目を作成する' })

--- a/treco-web/package.json
+++ b/treco-web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "TZ=Etc/UTC NODE_OPTIONS='-r newrelic' next dev",
-    "dev:no-auth-emulator": "next dev",
+    "dev:auth-jwt-no-encryption": "NEXT_AUTH_JWT_NO_ENCRYPTION=true GOOGLE_CLIENT_ID=id GOOGLE_CLIENT_SECRET=secret NEXT_AUTH_SECRET=secret NODE_OPTIONS='-r @newrelic/next' next dev",
     "build": "pnpm run format:check && prisma generate && prisma migrate deploy && next build",
     "start": "TZ=Etc/UTC GOOGLE_CLIENT_ID=id GOOGLE_CLIENT_SECRET=secret NEXT_AUTH_SECRET=secret NODE_OPTIONS='-r @newrelic/next' next start",
     "start:auth-jwt-no-encryption": "NEXT_AUTH_JWT_NO_ENCRYPTION=true GOOGLE_CLIENT_ID=id GOOGLE_CLIENT_SECRET=secret NEXT_AUTH_SECRET=secret NODE_OPTIONS='-r @newrelic/next' next start",

--- a/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
@@ -78,7 +78,7 @@ async function TrainingCategoriesPresenter({
   if (isSkeleton || trainingCategories.length) {
     return (
       <ul
-        aria-label="トレーニングカテゴリーリスト"
+        aria-label="トレーニングカテゴリー"
         className="flex w-full flex-col gap-2"
       >
         {isSkeleton

--- a/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/page.tsx
@@ -1,11 +1,14 @@
 import { TrainingMark } from '@/components/training-mark';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { PrismaTrainingCategoryQuery } from '@/domains/training-category/infrastructures/prisma.query';
+import { TrainingCategoryDto } from '@/domains/training-category/models/training-category';
 import { TrainingCategoryQueryByTraineeIdUsecase } from '@/domains/training-category/usecases/query-by-trainee-id.usecase';
 import { SearchParamsDateSchema, WithSearchParams } from '@/lib/searchParams';
 import { getSignedInTraineeId } from '@/lib/trainee';
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { object, parse } from 'valibot';
 
 import { CategoryDelete } from './_components/category-delete';
@@ -28,65 +31,135 @@ const SearchParamsSchema = object({
   date: SearchParamsDateSchema,
 });
 
-export default async function CategoryPage({ searchParams }: Props) {
-  const signedInTraineeId = await getSignedInTraineeId();
-
-  const categories = await queryCategories({ traineeId: signedInTraineeId });
-
+export default async function CategoriesPage({ searchParams }: Props) {
   const { date: selectedDate } = parse(SearchParamsSchema, searchParams);
 
   return (
-    <div className="p-2">
+    <div className="space-y-4 p-2">
       <p className="mb-4 text-sm text-muted-foreground">
         トレーニングカテゴリーを選択してください。左にスワイプすると削除できます。
       </p>
-
-      <ul
-        aria-label="トレーニングカテゴリーリスト"
-        className="flex w-full flex-col gap-2"
-      >
-        {categories.length ? (
-          categories.map(({ color, name, trainingCategoryId }) => (
-            <li
-              aria-label={name}
-              className={`flex snap-x snap-mandatory flex-nowrap overflow-x-scroll text-lg`}
-              key={trainingCategoryId}
-            >
-              <div className="flex h-16 w-full min-w-full grow snap-start items-center rounded-md bg-muted p-4">
-                <Link
-                  className="flex w-full items-center gap-4 text-foreground no-underline"
-                  href={{
-                    pathname: `/home/categories/${trainingCategoryId}/events`,
-                    query: {
-                      date: selectedDate.toISOString(),
-                    },
-                  }}
-                >
-                  <TrainingMark color={color} size="small" />
-                  <span className="grow text-3xl">{name}</span>
-                </Link>
-                <Button aria-label="カテゴリ名編集" variant={'ghost'}>
-                  <CategoryEdit
-                    color={color}
-                    name={name}
-                    trainingCategoryId={trainingCategoryId}
-                  />
-                </Button>
-              </div>
-              <div className="ml-4 h-16 w-16 snap-start">
-                <CategoryDelete trainingCategoryId={trainingCategoryId} />
-              </div>
-            </li>
-          ))
-        ) : (
-          <p className="p-4 text-center">
-            トレーニングカテゴリーが登録されていません。
-          </p>
-        )}
-      </ul>
+      <Suspense fallback={<TrainingCategoriesPresenter isSkeleton />}>
+        <TrainingCategoriesContainer date={selectedDate} />
+      </Suspense>
       <div className="mt-2">
         <CategoryEdit />
       </div>
     </div>
+  );
+}
+
+async function TrainingCategoriesContainer({ date }: { date: Date }) {
+  const signedInTraineeId = await getSignedInTraineeId();
+  const trainingCategories = await queryCategories({
+    traineeId: signedInTraineeId,
+  });
+
+  return (
+    <TrainingCategoriesPresenter
+      date={date}
+      trainingCategories={trainingCategories}
+    />
+  );
+}
+
+type TrainingCategoriesContainerProps =
+  | {
+      date: Date;
+      isSkeleton?: false;
+      trainingCategories: TrainingCategoryDto[];
+    }
+  | { date?: undefined; isSkeleton: true; trainingCategories?: undefined };
+async function TrainingCategoriesPresenter({
+  date,
+  isSkeleton,
+  trainingCategories,
+}: TrainingCategoriesContainerProps) {
+  if (isSkeleton || trainingCategories.length) {
+    return (
+      <ul
+        aria-label="トレーニングカテゴリーリスト"
+        className="flex w-full flex-col gap-2"
+      >
+        {isSkeleton
+          ? Array.from({ length: 6 }).map((_, i) => (
+              <TrainingCategoryItem isSkeleton key={i} />
+            ))
+          : trainingCategories.map((trainingCategory) => (
+              <TrainingCategoryItem
+                date={date}
+                key={trainingCategory.trainingCategoryId}
+                trainingCategory={trainingCategory}
+              />
+            ))}
+      </ul>
+    );
+  }
+
+  return (
+    <p className="p-4 text-center">
+      トレーニングカテゴリーが登録されていません。
+    </p>
+  );
+}
+
+type TrainingCategoryItemProps =
+  | {
+      date: Date;
+      isSkeleton?: false;
+      trainingCategory: TrainingCategoryDto;
+    }
+  | {
+      date?: undefined;
+      isSkeleton: true;
+      trainingCategory?: undefined;
+    };
+function TrainingCategoryItem({
+  date,
+  isSkeleton,
+  trainingCategory,
+}: TrainingCategoryItemProps) {
+  return (
+    <li className="flex snap-x snap-mandatory flex-nowrap overflow-x-scroll text-lg">
+      <div className="flex h-16 w-full min-w-full grow snap-start items-center rounded-md bg-muted p-4">
+        <Link
+          className="flex w-full items-center gap-4 text-foreground no-underline"
+          href={{
+            pathname: `/home/categories/${trainingCategory?.trainingCategoryId}/events`,
+            query: {
+              date: date?.toISOString(),
+            },
+          }}
+        >
+          <TrainingMark
+            {...(isSkeleton
+              ? { isSkeleton: true }
+              : { color: trainingCategory.color })}
+            size="small"
+          />
+          {isSkeleton ? (
+            <Skeleton className="h-4 w-16" />
+          ) : (
+            <span className="grow text-3xl">{trainingCategory.name}</span>
+          )}
+        </Link>
+        {!isSkeleton && (
+          <Button aria-label="カテゴリ名編集" variant={'ghost'}>
+            <CategoryEdit
+              color={trainingCategory?.color}
+              name={trainingCategory?.name}
+              trainingCategoryId={trainingCategory?.trainingCategoryId}
+            />
+          </Button>
+        )}
+      </div>
+      {!isSkeleton && (
+        <div className="ml-4 h-16 w-16 snap-start">
+          <CategoryDelete
+            trainingCategoryId={trainingCategory?.trainingCategoryId}
+          />
+        </div>
+      )}
+    </li>
   );
 }

--- a/treco-web/src/components/training-mark.tsx
+++ b/treco-web/src/components/training-mark.tsx
@@ -12,6 +12,7 @@ const sizeMap = {
 type Size = keyof typeof sizeMap;
 
 type SkeletonProps = {
+  color?: undefined;
   isSkeleton: true;
 };
 


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

treco-web/src/app/(header)/(auth)/home/categories/page.tsx: この変更では、`CategoryPage`コンポーネントが`CategoriesPage`にリネームされ、新しい`TrainingCategoriesContainer`と`TrainingCategoriesPresenter`コンポーネントが導入されました。`TrainingCategoriesContainer`はカテゴリーのデータを取得し、`TrainingCategoriesPresenter`はデータを表示します。また、`TrainingCategoryItem`コンポーネントも追加されました。これにより、トレーニングカテゴリーの一覧表示が改善され、スケルトンローディングもサポートされました。外部インターフェースや動作に影響を与える変更はありません。

treco-web/src/components/training-mark.tsx: この変更では、`SkeletonProps`型に`color`プロパティが追加されました。以前のバージョンでは、`SkeletonProps`は`isSkeleton`プロパティのみを持っていましたが、新しいバージョンでは`color`プロパティも受け入れるようになります。この変更は、コードの外部インターフェースや動作に影響を与える可能性があります。

treco-web/e2e/pages/training-event.page.ts: この変更では、`TrainingEventPage`クラスの`inputCategoryName`メソッドが修正されました。以前は、カテゴリー名をクリックするために`getByRole('listitem')`が使用されていましたが、新しいコードでは`getByRole('link')`が使用されるようになりました。これにより、カテゴリー名をクリックするための正しい要素が選択されるようになります。この変更は、外部インターフェースやコードの動作に影響を与える可能性はありません。

treco-web/e2e/pages/training-record.page.ts: この変更では、`TrainingRecordPage`クラスの`click()`メソッドの呼び出しが修正されています。以前は、`await this.page.getByRole('listitem', { name: categoryName }).click();`というコードがありましたが、これが`await this.page.getByRole('link', { name: categoryName }).click();`に変更されています。この変更により、カテゴリー名をクリックする際に使用される要素の種類が変わります。この変更は、コードの外部インターフェースや動作に影響を与える可能性があります。

treco-web/src/app/(header)/(auth)/home/categories/page.tsx: この変更では、カテゴリーページの改善が行われました。主な変更点は以下の通りです：

- `CategoryPage`コンポーネントが`CategoriesPage`にリネームされました。
- 新しい`TrainingCategoriesContainer`と`TrainingCategoriesPresenter`コンポーネントが導入されました。`TrainingCategoriesContainer`はカテゴリーのデータを取得し、`TrainingCategoriesPresenter`はデータを表示します。
- `TrainingCategoryItem`コンポーネントが追加されました。これにより、個々のトレーニングカテゴリーの表示と編集機能が追加されました。

これらの変更により、トレーニングカテゴリーの一覧表示が改善され、スケルトンローディングもサポートされました。また、カテゴリーページの表示と操作性も向上しました。

treco-web/e2e/pages/training-category.page
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->