### PR TITLE
カテゴリー名修正

### DIFF
--- a/treco-web/e2e/pages/training-event.page.ts
+++ b/treco-web/e2e/pages/training-event.page.ts
@@ -4,8 +4,8 @@ export class TrainingEventPage {
   private readonly loadUnitInputBox: Locator;
   private readonly nameInputBox: Locator;
   private readonly valueUnitInputBox: Locator;
+  readonly categoryNameGroup: Locator;
   readonly trainingEventItems: Locator;
-
   constructor(private page: Page) {
     this.trainingEventItems = page
       .getByRole('list', {
@@ -15,7 +15,9 @@ export class TrainingEventPage {
     this.nameInputBox = page.getByRole('textbox', { name: '名前' });
     this.loadUnitInputBox = page.getByRole('textbox', { name: '負荷の単位' });
     this.valueUnitInputBox = page.getByRole('textbox', { name: '値の単位' });
+    this.categoryNameGroup = page.getByTestId('category-name');
   }
+
   async addNewTrainingEvent(trainingEvent: {
     eventName: string;
     loadUnit: string;

--- a/treco-web/e2e/training-event.test.ts
+++ b/treco-web/e2e/training-event.test.ts
@@ -36,62 +36,90 @@ const events = [
   },
 ];
 
-const test = base.extend<{
-  trainingEventPage: TrainingEventPage;
-}>({
-  trainingEventPage: async ({ page }, use) => {
-    const trainingEventPage = new TrainingEventPage(page);
+base.describe('カテゴリ未作成状態', () => {
+  const test = base.extend<{
+    trainingEventPage: TrainingEventPage;
+  }>({
+    trainingEventPage: async ({ page }, use) => {
+      const trainingEventPage = new TrainingEventPage(page);
+
+      await use(trainingEventPage);
+    },
+  });
+
+  test('トレーニングカテゴリー名が表示される', async ({
+    trainingEventPage,
+  }) => {
     // カテゴリを作成
     const categoryName = randomUUID();
     await trainingEventPage.goToNewCategory(categoryName);
 
-    // トレーニング種目を作成
-    for (const event of events) {
-      await trainingEventPage.addNewTrainingEvent(event);
-    }
-
-    await use(trainingEventPage);
-  },
+    await expect(trainingEventPage.categoryNameGroup).toContainText(
+      categoryName,
+    );
+  });
 });
 
-test('トレーニング種目が作成順に表示される', async ({ trainingEventPage }) => {
-  expect(trainingEventPage.trainingEventItems).toHaveCount(events.length);
+base.describe('トレーニング種目作成済み状態', () => {
+  const test = base.extend<{
+    trainingEventPage: TrainingEventPage;
+  }>({
+    trainingEventPage: async ({ page }, use) => {
+      const trainingEventPage = new TrainingEventPage(page);
+      // カテゴリを作成
+      const categoryName = randomUUID();
+      await trainingEventPage.goToNewCategory(categoryName);
 
-  // 作成順に表示されていることを確認
-  await Promise.all(
-    events.map((event, index) =>
-      expect(trainingEventPage.trainingEventItems.nth(index)).toContainText(
-        event.eventName,
+      // トレーニング種目を作成
+      for (const event of events) {
+        await trainingEventPage.addNewTrainingEvent(event);
+      }
+
+      await use(trainingEventPage);
+    },
+  });
+
+  test('トレーニング種目が作成順に表示される', async ({
+    trainingEventPage,
+  }) => {
+    expect(trainingEventPage.trainingEventItems).toHaveCount(events.length);
+
+    // 作成順に表示されていることを確認
+    await Promise.all(
+      events.map((event, index) =>
+        expect(trainingEventPage.trainingEventItems.nth(index)).toContainText(
+          event.eventName,
+        ),
       ),
-    ),
-  );
+    );
 
-  // TODO: 単位の確認
-});
+    // TODO: 単位の確認
+  });
 
-test('トレーニング種目を編集できる', async ({ trainingEventPage }) => {
-  const editEvent = {
-    eventName: '編集済み種目',
-    loadUnit: 'kg編集済み',
-    valueUnit: '回編集済み',
-  };
-  await trainingEventPage.editTrainingEvent(0, editEvent);
+  test('トレーニング種目を編集できる', async ({ trainingEventPage }) => {
+    const editEvent = {
+      eventName: '編集済み種目',
+      loadUnit: 'kg編集済み',
+      valueUnit: '回編集済み',
+    };
+    await trainingEventPage.editTrainingEvent(0, editEvent);
 
-  // 編集されていることを確認
-  await expect(trainingEventPage.trainingEventItems.nth(0)).toContainText(
-    editEvent.eventName,
-  );
+    // 編集されていることを確認
+    await expect(trainingEventPage.trainingEventItems.nth(0)).toContainText(
+      editEvent.eventName,
+    );
 
-  // TODO: 単位の確認
-});
+    // TODO: 単位の確認
+  });
 
-test('トレーニング種目を削除できる', async ({ trainingEventPage }) => {
-  await trainingEventPage.removeTrainingEvent(1);
+  test('トレーニング種目を削除できる', async ({ trainingEventPage }) => {
+    await trainingEventPage.removeTrainingEvent(1);
 
-  await expect(trainingEventPage.trainingEventItems).toHaveCount(
-    events.length - 1,
-  );
-  await expect(trainingEventPage.trainingEventItems.nth(1)).toContainText(
-    events[2].eventName,
-  );
+    await expect(trainingEventPage.trainingEventItems).toHaveCount(
+      events.length - 1,
+    );
+    await expect(trainingEventPage.trainingEventItems.nth(1)).toContainText(
+      events[2].eventName,
+    );
+  });
 });

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/page.tsx
@@ -76,7 +76,7 @@ export default async function TrainingEventPage({
         トレーニング種目を選択してください
       </p>
       <div className="mb-4 flex items-center gap-2">
-        <TrainingMark color={category.color} size="small" /> 胸
+        <TrainingMark color={category.color} size="small" /> {category.name}
       </div>
 
       <ul

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/page.tsx
@@ -75,7 +75,7 @@ export default async function TrainingEventPage({
       <p className="mb-4 text-sm text-muted-foreground">
         トレーニング種目を選択してください
       </p>
-      <div className="mb-4 flex items-center gap-2">
+      <div className="mb-4 flex items-center gap-2" data-testid="category-name">
         <TrainingMark color={category.color} size="small" /> {category.name}
       </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容に関するリリースノートです。

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/page.tsx:
- カテゴリー名が修正されました。以前は「胸」と表示されていましたが、新しいカテゴリー名に変更されました。この変更は外部インターフェースやコードの動作に影響を与える可能性はありません。ただし、カテゴリー名が表示される箇所でのみ変更が行われています。

treco-web/e2e/pages/training-event.page.ts:
- `TrainingEventPage`クラスに新しいプロパティ`categoryNameGroup`が追加されました。
- `addNewTrainingEvent`メソッドの実装にも変更があります。これにより、トレーニングイベントのカテゴリー名を取得するための要素が追加されます。
- 外部インターフェースやコードの動作に影響を与える可能性がある変更はありません。

treco-web/e2e/training-event.test.ts:
- テストスイート内のいくつかのテストケースが追加および修正されました。
- 新しいテストケースでは、カテゴリが作成された後にトレーニングカテゴリ名が表示されることを確認しています。
- 既存のテストケースでは、以下の項目が確認されます：
  - トレーニング種目が作成順に表示されること
  - トレーニング種目の編集が可能であること
  - トレーニング種目の削除が可能であること
- これらの変更は、外部インターフェースやコードの動作に影響を与える可能性があります。

以上がファイルの変更内容に関するリリースノートです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->