### PR TITLE
Suspense 化

### DIFF
--- a/treco-web/e2e/pages/training-event.page.ts
+++ b/treco-web/e2e/pages/training-event.page.ts
@@ -8,9 +8,7 @@ export class TrainingEventPage {
   readonly trainingEventItems: Locator;
   constructor(private page: Page) {
     this.trainingEventItems = page
-      .getByRole('list', {
-        name: 'トレーニング種目リスト',
-      })
+      .getByRole('list', { name: 'トレーニング種目' })
       .getByRole('listitem');
     this.nameInputBox = page.getByRole('textbox', { name: '名前' });
     this.loadUnitInputBox = page.getByRole('textbox', { name: '負荷の単位' });

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events-page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events-page.tsx
@@ -1,6 +1,11 @@
+import { Suspense } from 'react';
+
 import { EventEdit } from './event-edit';
 import { TrainingCategoryLabelContainer } from './training-category-label';
-import { TrainingEventsContainer } from './training-events';
+import {
+  TrainingEventsContainer,
+  TrainingEventsPresenter,
+} from './training-events';
 
 type TrainingEventsPageProps = {
   categoryId: string;
@@ -16,8 +21,9 @@ export function TrainingEventsPage({
         トレーニング種目を選択してください
       </p>
       <TrainingCategoryLabelContainer categoryId={categoryId} />
-      <TrainingEventsContainer categoryId={categoryId} date={date} />
-
+      <Suspense fallback={<TrainingEventsPresenter isSkeleton />}>
+        <TrainingEventsContainer categoryId={categoryId} date={date} />
+      </Suspense>
       <EventEdit trainingCategoryId={categoryId} />
     </div>
   );

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from '@/components/ui/skeleton';
 import { getSignedInTraineeId } from '@/lib/trainee';
 
 import { createNewRecordAction } from '../_actions';
@@ -33,6 +34,7 @@ type TrainingEventsPresenterProps = {
     trainingCategoryId: string;
   };
   date: Date;
+  isSkeleton?: false;
   traineeId: string;
   trainingEvents: {
     loadUnit: string;
@@ -41,69 +43,127 @@ type TrainingEventsPresenterProps = {
     valueUnit: string;
   }[];
 };
-function TrainingEventsPresenter({
+
+type TrainingEventsPresenterSkeletonProps = Partial<
+  Omit<TrainingEventsPresenterProps, 'isSkeleton'>
+> & {
+  isSkeleton: true;
+};
+export function TrainingEventsPresenter({
   category,
   date,
+  isSkeleton,
   traineeId,
   trainingEvents,
-}: TrainingEventsPresenterProps) {
-  return (
-    <ul
-      aria-label={`${category.name}のトレーニング種目リスト`}
-      className="mb-2 flex w-full flex-col gap-2"
-    >
-      {trainingEvents.length ? (
-        trainingEvents.map(({ loadUnit, name, trainingEventId, valueUnit }) => (
-          <li
-            aria-label={name}
-            className={`flex snap-x snap-mandatory flex-nowrap overflow-x-scroll`}
-            key={trainingEventId}
-          >
-            <form
-              action={createNewRecordAction}
-              className="flex h-16 w-full min-w-full grow snap-start items-center rounded-md bg-muted p-4"
-            >
-              <input
-                name="trainingDate"
-                type="hidden"
-                value={date.toISOString()}
+}: TrainingEventsPresenterProps | TrainingEventsPresenterSkeletonProps) {
+  if (isSkeleton || trainingEvents.length) {
+    return (
+      <ul
+        aria-label={
+          isSkeleton ? 'トレーニング種目' : `${category.name}のトレーニング種目`
+        }
+        className="mb-2 flex w-full flex-col gap-2"
+      >
+        {isSkeleton
+          ? Array.from({ length: 6 }).map((_, i) => (
+              <TrainingEventItem isSkeleton key={i} />
+            ))
+          : trainingEvents.map((trainingEvent) => (
+              <TrainingEventItem
+                category={category}
+                date={date}
+                key={trainingEvent.trainingEventId}
+                traineeId={traineeId}
+                {...trainingEvent}
               />
-              <input
-                name="trainingCategoryId"
-                type="hidden"
-                value={category.trainingCategoryId}
-              />
-              <input
-                name="trainingEventId"
-                type="hidden"
-                value={trainingEventId}
-              />
-              <input name="traineeId" type="hidden" value={traineeId} />
-              <button className="block w-full overflow-x-hidden text-ellipsis whitespace-nowrap text-left text-foreground no-underline">
-                <span className="grow text-xl ">{name}</span>
-              </button>
+            ))}
+      </ul>
+    );
+  }
 
-              <EventEdit
-                loadUnit={loadUnit}
-                name={name}
-                trainingCategoryId={category.trainingCategoryId}
-                trainingEventId={trainingEventId}
-                valueUnit={valueUnit}
-              />
-            </form>
-            <div className="ml-4 h-16 w-16 snap-start">
-              <EventDelete
-                trainingCategoryId={category.trainingCategoryId}
-                trainingEventId={trainingEventId}
-              />
-            </div>
-          </li>
-        ))
+  return (
+    <p className="p-4 text-center">トレーニング種目が登録されていません。</p>
+  );
+}
+
+type TrainingEventItemProps = {
+  category: {
+    trainingCategoryId: string;
+  };
+  date: Date;
+  isSkeleton?: false;
+  loadUnit: string;
+  name: string;
+  traineeId: string;
+  trainingEventId: string;
+  valueUnit: string;
+};
+
+type TrainingEventItemSkeletonProps = Partial<
+  Omit<TrainingEventItemProps, 'isSkeleton'>
+> & { isSkeleton: true };
+
+function TrainingEventItem({
+  category,
+  date,
+  isSkeleton,
+  loadUnit,
+  name,
+  traineeId,
+  trainingEventId,
+  valueUnit,
+}: TrainingEventItemProps | TrainingEventItemSkeletonProps) {
+  return (
+    <li
+      aria-label={name}
+      className={`flex snap-x snap-mandatory flex-nowrap overflow-x-auto`}
+    >
+      {isSkeleton ? (
+        <div className="flex h-16 min-w-full grow snap-start items-center rounded-md bg-muted p-4">
+          <Skeleton className="h-5 w-32" />
+        </div>
       ) : (
-        <p className="p-4 text-center">
-          トレーニング種目が登録されていません。
-        </p>
+        <>
+          <form
+            action={createNewRecordAction}
+            className="flex h-16 min-w-full grow snap-start items-center rounded-md bg-muted p-4"
+          >
+            <input
+              name="trainingDate"
+              type="hidden"
+              value={date.toISOString()}
+            />
+            <input
+              name="trainingCategoryId"
+              type="hidden"
+              value={category.trainingCategoryId}
+            />
+            <input
+              name="trainingEventId"
+              type="hidden"
+              value={trainingEventId}
+            />
+            <input name="traineeId" type="hidden" value={traineeId} />
+            <button className="block w-full overflow-x-hidden text-ellipsis whitespace-nowrap text-left text-foreground no-underline">
+              <span className="grow text-xl ">{name}</span>
+            </button>
+
+            <EventEdit
+              loadUnit={loadUnit}
+              name={name}
+              trainingCategoryId={category.trainingCategoryId}
+              trainingEventId={trainingEventId}
+              valueUnit={valueUnit}
+            />
+          </form>
+          <div className="ml-4 h-16 w-16 snap-start">
+            <EventDelete
+              trainingCategoryId={category.trainingCategoryId}
+              trainingEventId={trainingEventId}
+            />
+          </div>
+        </>
       )}
-    </ul>
+    </li>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events-page.tsx:
- Reactの`Suspense`コンポーネントを導入しました。`TrainingEventsContainer`コンポーネントを`Suspense`でラップし、データのロード中に表示されるスケルトンを提供します。これにより、ユーザーがデータの読み込みを待つ間に、UIがブロックされないようになります。外部インターフェースやコードの振る舞いに影響を与える変更はありませんが、コンポーネントのレンダリングとデータの取得方法が変更されています。

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events.tsx:
- `TrainingEventsPresenter`コンポーネントに`skeleton`プロパティが追加されました。これにより、スケルトン状態の表示が可能になります。
- `TrainingEventItem`コンポーネントも同様に`skeleton`プロパティが追加され、スケルトン状態の表示が可能になりました。
- これらの変更は、トレーニング種目が登録されていない場合やデータがまだ読み込まれていない場合に、適切な表示を行うためのものです。

treco-web/e2e/pages/training-event.page.ts:
- この変更は、`TrainingEventPage`クラスのコンストラクタ内で行われています。変更点は、`trainingEventItems`プロパティの初期化時に使用される`getByRole`メソッドの引数です。以前は、`name`プロパティの値が「トレーニング種目リスト」でしたが、変更後は「トレーニング種目」となっています。この変更により、`trainingEventItems`プロパティは正しく初期化されます。
- この変更は、外部インターフェースやコードの動作に影響を与える可能性はありません。ただし、`TrainingEventPage`クラスの他の部分で`trainingEventItems`プロパティを使用している場合は、変更後の引数に合わせて修正する必要があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->