### PR TITLE
トレーニング記録 suspense

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/submit-button.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/submit-button.tsx
@@ -5,10 +5,13 @@ import { ReloadIcon } from '@radix-ui/react-icons';
 import { PropsWithChildren } from 'react';
 import { useFormStatus } from 'react-dom';
 
-export function SubmitButton({ children }: PropsWithChildren) {
+export function SubmitButton({
+  children,
+  disabled,
+}: PropsWithChildren<{ disabled?: boolean }>) {
   const { pending } = useFormStatus();
   return (
-    <Button disabled={pending}>
+    <Button disabled={pending || disabled}>
       {pending ? <ReloadIcon className="animate-spin" /> : children}
     </Button>
   );

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-event-label.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-event-label.tsx
@@ -1,4 +1,5 @@
 import { TrainingMark } from '@/components/training-mark';
+import { Skeleton } from '@/components/ui/skeleton';
 
 import { cachedQueryTrainingRecordEdit } from '../queries';
 
@@ -19,22 +20,42 @@ export async function TrainingEventLabelContainer({
     />
   );
 }
+
 type TrainingEventLabelPresenterProps = {
+  isSkeleton?: false;
   trainingCategoryColor: string;
   trainingCategoryName: string;
   trainingEventName: string;
 };
-function TrainingEventLabelPresenter({
+type TrainingEventLabelPresenterSkeletonProps = Partial<
+  Omit<TrainingEventLabelPresenterProps, 'isSkeleton'>
+> & { isSkeleton: true };
+
+export function TrainingEventLabelPresenter({
+  isSkeleton,
   trainingCategoryColor,
   trainingCategoryName,
   trainingEventName,
-}: TrainingEventLabelPresenterProps) {
+}:
+  | TrainingEventLabelPresenterProps
+  | TrainingEventLabelPresenterSkeletonProps) {
   return (
     <div className="flex w-full shrink-0 items-center gap-2 px-4">
-      <TrainingMark color={trainingCategoryColor} size="small" />
-      <span>{trainingCategoryName}</span>
+      <TrainingMark
+        size="small"
+        {...(isSkeleton
+          ? { isSkeleton: true }
+          : {
+              color: trainingCategoryColor,
+            })}
+      />
+      <span>
+        {isSkeleton ? <Skeleton className="h-5 w-32" /> : trainingCategoryName}
+      </span>
       <span>&gt;</span>
-      <span>{trainingEventName}</span>
+      <span>
+        {isSkeleton ? <Skeleton className="h-5 w-32" /> : trainingEventName}
+      </span>
     </div>
   );
 }

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-form.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-form.tsx
@@ -45,6 +45,7 @@ export async function TrainingRecordEditFormContainer({
 
 type TrainingRecordEditFormPresenterProps = {
   isEditing: boolean;
+  isSkeleton?: false;
   load: number | string;
   note: string;
   selectedSetIndex: number | undefined;
@@ -52,15 +53,23 @@ type TrainingRecordEditFormPresenterProps = {
   trainingRecordId: string;
   value: number | string;
 };
+
+type TrainingRecordEditFormPresenterSkeletonProps = Partial<
+  Omit<TrainingRecordEditFormPresenterProps, 'isSkeleton'>
+> & { isSkeleton: true };
+
 export function TrainingRecordEditFormPresenter({
   isEditing,
+  isSkeleton,
   load,
   note,
   selectedSetIndex,
   traineeId,
   trainingRecordId,
   value,
-}: TrainingRecordEditFormPresenterProps) {
+}:
+  | TrainingRecordEditFormPresenterProps
+  | TrainingRecordEditFormPresenterSkeletonProps) {
   return (
     <form
       action={isEditing ? editSetAction : addSetAction}
@@ -80,6 +89,7 @@ export function TrainingRecordEditFormPresenter({
           </label>
           <Input
             defaultValue={load}
+            disabled={isSkeleton}
             id="load"
             inputMode="decimal"
             name="load"
@@ -94,6 +104,7 @@ export function TrainingRecordEditFormPresenter({
           </label>
           <Input
             defaultValue={value}
+            disabled={isSkeleton}
             id="value"
             inputMode="decimal"
             name="value"
@@ -110,13 +121,16 @@ export function TrainingRecordEditFormPresenter({
         <Textarea
           className="h-1 grow"
           defaultValue={note}
+          disabled={isSkeleton}
           id="note"
           name="note"
         />
       </div>
       <div className="flex justify-end gap-2">
         {isEditing && <CancelButton />}
-        <SubmitButton>{isEditing ? '変更する' : '追加する'}</SubmitButton>
+        <SubmitButton disabled={isSkeleton}>
+          {isEditing ? '変更する' : '追加する'}
+        </SubmitButton>
       </div>
     </form>
   );

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-page.tsx
@@ -1,6 +1,14 @@
-import { TrainingEventLabelContainer } from './training-event-label';
-import { TrainingRecordEditFormContainer } from './training-record-edit-form';
-import { TrainingSetsContainer } from './training-sets';
+import { Suspense } from 'react';
+
+import {
+  TrainingEventLabelContainer,
+  TrainingEventLabelPresenter,
+} from './training-event-label';
+import {
+  TrainingRecordEditFormContainer,
+  TrainingRecordEditFormPresenter,
+} from './training-record-edit-form';
+import { TrainingSetsContainer, TrainingSetsPresenter } from './training-sets';
 
 type TrainingRecordEditPageProps = {
   selectedSetIndex?: number;
@@ -12,15 +20,21 @@ export default async function TrainingRecordEditPage({
 }: TrainingRecordEditPageProps) {
   return (
     <div className="flex h-full w-full flex-col">
-      <TrainingEventLabelContainer trainingRecordId={trainingRecordId} />
-      <TrainingSetsContainer
-        selectedIndex={selectedSetIndex}
-        trainingRecordId={trainingRecordId}
-      />
-      <TrainingRecordEditFormContainer
-        selectedSetIndex={selectedSetIndex}
-        trainingRecordId={trainingRecordId}
-      />
+      <Suspense fallback={<TrainingEventLabelPresenter isSkeleton />}>
+        <TrainingEventLabelContainer trainingRecordId={trainingRecordId} />
+      </Suspense>
+      <Suspense fallback={<TrainingSetsPresenter isSkeleton />}>
+        <TrainingSetsContainer
+          selectedIndex={selectedSetIndex}
+          trainingRecordId={trainingRecordId}
+        />
+      </Suspense>
+      <Suspense fallback={<TrainingRecordEditFormPresenter isSkeleton />}>
+        <TrainingRecordEditFormContainer
+          selectedSetIndex={selectedSetIndex}
+          trainingRecordId={trainingRecordId}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-sets.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-sets.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from '@/components/ui/skeleton';
 import { TrainingEventDto } from '@/domains/training-event/models/training-event';
 import { TrainingSet } from '@/domains/training-record/models/training-record';
 import clsx from 'clsx';
@@ -28,17 +29,24 @@ export async function TrainingSetsContainer({
 }
 
 type TrainingSetsPresenterProps = {
+  isSkeleton?: false;
   selectedIndex?: number;
   sets: TrainingSet[];
   trainingEvent: TrainingEventDto;
   trainingRecordId: string;
 };
+type TrainingSetsPresenterSkeletonProps = Partial<
+  Omit<TrainingSetsPresenterProps, 'isSkeleton'>
+> & {
+  isSkeleton: true;
+};
 export function TrainingSetsPresenter({
+  isSkeleton,
   selectedIndex,
   sets,
   trainingEvent,
   trainingRecordId,
-}: TrainingSetsPresenterProps) {
+}: TrainingSetsPresenterProps | TrainingSetsPresenterSkeletonProps) {
   return (
     <>
       <div className="top-11 flex shrink-0 p-2 text-xs text-muted-foreground">
@@ -48,7 +56,11 @@ export function TrainingSetsPresenter({
         <div className="grow">備考</div>
       </div>
       <div className="h-full overflow-y-auto bg-muted p-4">
-        {sets.length ? (
+        {isSkeleton ? (
+          Array.from({ length: 6 }, (_, index) => (
+            <TrainingSetItem index={index} isSkeleton key={index} />
+          ))
+        ) : sets.length ? (
           <ul aria-label="トレーニングセット">
             {sets.map((set, index) => (
               <TrainingSetItem
@@ -76,17 +88,25 @@ export function TrainingSetsPresenter({
 type TrainingSetItemProps = {
   index: number;
   isSelected: boolean;
+  isSkeleton?: false;
   set: TrainingSet;
   trainingEvent: TrainingEventDto;
   trainingRecordId: string;
 };
+type TrainingSetItemSkeletonProps = Partial<
+  Omit<TrainingSetItemProps, 'index' | 'isSkeleton'>
+> &
+  Pick<TrainingSetItemProps, 'index'> & {
+    isSkeleton: true;
+  };
 function TrainingSetItem({
   index,
   isSelected,
-  set: { load, note, value },
+  isSkeleton,
+  set,
   trainingEvent,
   trainingRecordId,
-}: TrainingSetItemProps) {
+}: TrainingSetItemProps | TrainingSetItemSkeletonProps) {
   return (
     <li
       aria-labelledby={`set-label${index}`}
@@ -109,31 +129,55 @@ function TrainingSetItem({
         aria-label="負荷"
         className="mr-1 flex w-12 items-center justify-end"
       >
-        {load}
-        <span className="sr-only ml-1 text-xs">{trainingEvent.loadUnit}</span>
+        {isSkeleton ? (
+          <Skeleton className="h-5 w-4" />
+        ) : (
+          <>
+            {set.load}
+            <span className="sr-only ml-1 text-xs">
+              {trainingEvent.loadUnit}
+            </span>
+          </>
+        )}
       </div>
       <div aria-label="値" className="mr-8 flex w-12 items-center justify-end">
-        {value}
-        <span className="sr-only ml-1 text-xs">{trainingEvent.valueUnit}</span>
+        {isSkeleton ? (
+          <Skeleton className="h-5 w-4" />
+        ) : (
+          <>
+            {set.value}
+            <span className="sr-only ml-1 text-xs">
+              {trainingEvent.valueUnit}
+            </span>
+          </>
+        )}
       </div>
       <div aria-label="備考" className="flex grow items-center">
         <div className="max-h-10 w-12 grow overflow-y-auto whitespace-pre p-3 text-xs">
-          {note || (
+          {isSkeleton ? (
+            <Skeleton className="h-5 w-12" />
+          ) : (
             <>
-              <span aria-hidden>-</span>
-              <span className="sr-only">なし</span>
+              {set.note || (
+                <>
+                  <span aria-hidden>-</span>
+                  <span className="sr-only">なし</span>
+                </>
+              )}
             </>
           )}
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
-        <EditButton index={index} />
-        <SetDelete
-          trainingRecordId={trainingRecordId}
-          trainingSetIndex={index}
-        />
-      </div>
+      {!isSkeleton && (
+        <div className="flex items-center gap-2">
+          <EditButton index={index} />
+          <SetDelete
+            trainingRecordId={trainingRecordId}
+            trainingSetIndex={index}
+          />
+        </div>
+      )}
     </li>
   );
 }

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/page.tsx
@@ -2,7 +2,6 @@ import { WithParams, WithSearchParams } from '@/lib/searchParams';
 import { object, optional, parse, regex, string, transform } from 'valibot';
 
 import TrainingRecordEditPage from './_components/training-record-edit-page';
-import { cachedQueryTrainingRecordEdit } from './queries';
 
 type Props = WithParams<'recordId', WithSearchParams>;
 
@@ -10,13 +9,9 @@ const SearchParamsSchema = object({
   edit: optional(transform(string([regex(/[0-9]+/)]), Number)),
 });
 
-export async function generateMetadata({ params }: Props) {
-  const { trainingEvent } = await cachedQueryTrainingRecordEdit(
-    params.recordId,
-  );
-
+export async function generateMetadata() {
   return {
-    title: `${trainingEvent.name} の記録`,
+    title: 'トレーニングを記録',
   };
 }
 

--- a/treco-web/src/components/training-mark.tsx
+++ b/treco-web/src/components/training-mark.tsx
@@ -11,29 +11,28 @@ const sizeMap = {
 
 type Size = keyof typeof sizeMap;
 
-type SkeletonProps = {
-  color?: undefined;
-  isSkeleton: true;
-};
-
 type NormalProps = {
   color: string;
   isSkeleton?: false;
-};
-
-type Props = (NormalProps | SkeletonProps) & {
   size: Size;
 };
 
-export function TrainingMark(props: Props) {
-  const size = sizeMap[props.size];
+type SkeletonProps = Pick<NormalProps, 'size'> & {
+  color?: string;
+  isSkeleton: true;
+};
 
-  return props.isSkeleton ? (
-    <Skeleton className={clsx(size, 'rounded-full')} />
+type Props = NormalProps | SkeletonProps;
+
+export function TrainingMark({ color, isSkeleton, size }: Props) {
+  const sizeClass = sizeMap[size];
+
+  return isSkeleton ? (
+    <Skeleton className={clsx(sizeClass, 'rounded-full')} />
   ) : (
     <div
-      className={clsx(size, 'rounded-full')}
-      style={{ backgroundColor: props.color }}
+      className={clsx(sizeClass, 'rounded-full')}
+      style={{ backgroundColor: color }}
     />
   );
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です。

- `treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/submit-button.tsx`:
  - `SubmitButton`コンポーネントに`disabled`プロパティが追加されました。これにより、ボタンが無効化されるかどうかを制御できます。
  - `useFormStatus`フックから取得した`pending`ステータスも考慮されています。

- `treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-event-label.tsx`:
  - `TrainingEventLabelPresenter`コンポーネントに`skeleton`プロパティが追加されました。これにより、スケルトンの表示が可能になります。
  - `TrainingMark`コンポーネントの`color`プロパティを条件付きで設定するための変更も含まれています。

- `treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-form.tsx`:
  - `TrainingRecordEditFormPresenter`コンポーネントに`skeleton`プロパティが追加されました。これにより、読み込み中やデータがない場合にスケルトン状態を表示できます。
  - 入力フィールドとボタンを無効化するための条件分岐も追加されました。
  - `SubmitButton`も無効化されるようになります。

- `treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-page.tsx`:
  - トレーニング記録の編集ページに`Suspense`が導入されました。
  - `TrainingEventLabelContainer`、`TrainingSetsContainer`、`TrainingRecordEditFormContainer`の各コンポーネントを`Suspense`でラップし、データがまだ読み込まれていない場合にスケルトンを表示するようになりました。

- `treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-sets.tsx`:
  - `TrainingSetsPresenter`と`TrainingSetItem`コンポーネントに`suspense`が追加されました。

変更セットの要約は以上です。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->