### PR TITLE
server action bind

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_actions/create-new-record.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_actions/create-new-record.action.ts
@@ -2,44 +2,23 @@
 
 import { PrismaTrainingRecordRepository } from '@/domains/training-record/infrastructures/prisma.repository';
 import { TrainingRecordCreateUsecase } from '@/domains/training-record/usecases/create.usecase';
+import { getSignedInTraineeId } from '@/lib/trainee';
 import { redirect } from 'next/navigation';
-import { ValiError, object, parse, string, uuid } from 'valibot';
-
-const inputSchema = object({
-  traineeId: string([uuid()]),
-  trainingCategoryId: string([uuid()]),
-  trainingDate: string(),
-  trainingEventId: string([uuid()]),
-});
 
 const createUsecase = new TrainingRecordCreateUsecase(
   new PrismaTrainingRecordRepository(),
 );
 
-export async function createNewRecordAction(formData: FormData) {
-  let input;
-  try {
-    input = parse(inputSchema, Object.fromEntries(formData.entries()));
-  } catch (e) {
-    if (e instanceof ValiError) {
-      console.error(
-        'validation error',
-        JSON.stringify({
-          error: e,
-          func: 'createNewRecordAction',
-        }),
-      );
-      throw new Error('validation error');
-    }
-    console.error('unknown error', {
-      func: 'createNewRecordAction',
-    });
-    throw new Error('unknown error');
-  }
-
+type CreateNewRecordActionProps = {
+  trainingCategoryId: string;
+  trainingDate: Date;
+  trainingEventId: string;
+};
+export async function createNewRecordAction(props: CreateNewRecordActionProps) {
   const newRecord = await createUsecase.execute({
-    ...input,
-    trainingDate: new Date(input.trainingDate),
+    ...props,
+    traineeId: await getSignedInTraineeId(),
+    trainingDate: new Date(props.trainingDate),
   });
 
   redirect(`/home/records/${newRecord.trainingRecordId}`);

--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from '@/components/ui/skeleton';
-import { getSignedInTraineeId } from '@/lib/trainee';
 
 import { createNewRecordAction } from '../_actions';
 import { cachedQueryCategory, queryTrainingEvents } from '../_queries/queries';
@@ -14,8 +13,6 @@ export async function TrainingEventsContainer({
   categoryId,
   date,
 }: TrainingEventsContainerProps) {
-  const signedInTraineeId = await getSignedInTraineeId();
-
   const category = await cachedQueryCategory(categoryId);
   const trainingEvents = await queryTrainingEvents(categoryId);
 
@@ -23,7 +20,6 @@ export async function TrainingEventsContainer({
     <TrainingEventsPresenter
       category={category}
       date={date}
-      traineeId={signedInTraineeId}
       trainingEvents={trainingEvents}
     />
   );
@@ -35,7 +31,6 @@ type TrainingEventsPresenterProps = {
   };
   date: Date;
   isSkeleton?: false;
-  traineeId: string;
   trainingEvents: {
     loadUnit: string;
     name: string;
@@ -53,7 +48,6 @@ export function TrainingEventsPresenter({
   category,
   date,
   isSkeleton,
-  traineeId,
   trainingEvents,
 }: TrainingEventsPresenterProps | TrainingEventsPresenterSkeletonProps) {
   if (isSkeleton || trainingEvents.length) {
@@ -73,7 +67,6 @@ export function TrainingEventsPresenter({
                 category={category}
                 date={date}
                 key={trainingEvent.trainingEventId}
-                traineeId={traineeId}
                 {...trainingEvent}
               />
             ))}
@@ -94,7 +87,6 @@ type TrainingEventItemProps = {
   isSkeleton?: false;
   loadUnit: string;
   name: string;
-  traineeId: string;
   trainingEventId: string;
   valueUnit: string;
 };
@@ -109,7 +101,6 @@ function TrainingEventItem({
   isSkeleton,
   loadUnit,
   name,
-  traineeId,
   trainingEventId,
   valueUnit,
 }: TrainingEventItemProps | TrainingEventItemSkeletonProps) {
@@ -125,25 +116,13 @@ function TrainingEventItem({
       ) : (
         <>
           <form
-            action={createNewRecordAction}
+            action={createNewRecordAction.bind(null, {
+              trainingCategoryId: category.trainingCategoryId,
+              trainingDate: date,
+              trainingEventId,
+            })}
             className="flex h-16 min-w-full grow snap-start items-center rounded-md bg-muted p-4"
           >
-            <input
-              name="trainingDate"
-              type="hidden"
-              value={date.toISOString()}
-            />
-            <input
-              name="trainingCategoryId"
-              type="hidden"
-              value={category.trainingCategoryId}
-            />
-            <input
-              name="trainingEventId"
-              type="hidden"
-              value={trainingEventId}
-            />
-            <input name="traineeId" type="hidden" value={traineeId} />
             <button className="block w-full overflow-x-hidden text-ellipsis whitespace-nowrap text-left text-foreground no-underline">
               <span className="grow text-xl ">{name}</span>
             </button>

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_actions/add-set.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_actions/add-set.action.ts
@@ -2,22 +2,13 @@
 
 import { PrismaTrainingRecordRepository } from '@/domains/training-record/infrastructures/prisma.repository';
 import { TrainingRecordAddSetUsecase } from '@/domains/training-record/usecases/add-set.usecase';
+import { getSignedInTraineeId } from '@/lib/trainee';
 import { revalidatePath } from 'next/cache';
-import {
-  coerce,
-  maxLength,
-  number,
-  object,
-  parse,
-  string,
-  uuid,
-} from 'valibot';
+import { coerce, maxLength, number, object, parse, string } from 'valibot';
 
 const inputSchema = object({
   load: coerce(number(), Number),
   note: string([maxLength(255)]),
-  traineeId: string(),
-  trainingRecordId: string([uuid()]),
   value: coerce(number(), Number),
 });
 
@@ -25,26 +16,15 @@ const addSetUsecase = new TrainingRecordAddSetUsecase(
   new PrismaTrainingRecordRepository(),
 );
 
-export async function addSetAction(formData: FormData) {
-  let input;
-  try {
-    input = parse(inputSchema, {
-      ...Object.fromEntries(formData.entries()),
-      load: formData.get('load'),
-      value: formData.get('value'),
-    });
-    // TODO
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (e: any) {
-    console.error('validation error', {
-      issue: JSON.stringify(e, null, 4),
-      message: e.message,
-      stack: e.stack,
-    });
-    throw new Error('validatin error');
-  }
+type Props = {
+  trainingRecordId: string;
+};
+export async function addSetAction(props: Props, formData: FormData) {
+  await addSetUsecase.execute({
+    ...parse(inputSchema, Object.fromEntries(formData.entries())),
+    ...props,
+    traineeId: await getSignedInTraineeId(),
+  });
 
-  const trainingRecord = await addSetUsecase.execute(input);
-
-  revalidatePath(`/home/records/${trainingRecord.trainingRecordId}`);
+  revalidatePath(`/home/records/${props.trainingRecordId}`);
 }

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-form.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/training-record-edit-form.tsx
@@ -1,6 +1,5 @@
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { getSignedInTraineeId } from '@/lib/trainee';
 
 import { addSetAction, editSetAction } from '../_actions';
 import { cachedQueryTrainingRecordEdit } from '../queries';
@@ -15,10 +14,7 @@ export async function TrainingRecordEditFormContainer({
   selectedSetIndex,
   trainingRecordId,
 }: TrainingRecordEditFormContainerProps) {
-  const [{ sets }, traineeId] = await Promise.all([
-    cachedQueryTrainingRecordEdit(trainingRecordId),
-    await getSignedInTraineeId(),
-  ]);
+  const { sets } = await cachedQueryTrainingRecordEdit(trainingRecordId);
 
   const {
     load: loadDefaultValue,
@@ -36,7 +32,6 @@ export async function TrainingRecordEditFormContainer({
       load={loadDefaultValue}
       note={noteDefaultValue}
       selectedSetIndex={selectedSetIndex}
-      traineeId={traineeId}
       trainingRecordId={trainingRecordId}
       value={valueDefaultValue}
     />
@@ -49,7 +44,6 @@ type TrainingRecordEditFormPresenterProps = {
   load: number | string;
   note: string;
   selectedSetIndex: number | undefined;
-  traineeId: string;
   trainingRecordId: string;
   value: number | string;
 };
@@ -64,24 +58,27 @@ export function TrainingRecordEditFormPresenter({
   load,
   note,
   selectedSetIndex,
-  traineeId,
   trainingRecordId,
   value,
 }:
   | TrainingRecordEditFormPresenterProps
   | TrainingRecordEditFormPresenterSkeletonProps) {
+  const action = isSkeleton
+    ? undefined
+    : isEditing && selectedSetIndex != null
+    ? editSetAction.bind(null, {
+        index: selectedSetIndex,
+        trainingRecordId,
+      })
+    : addSetAction.bind(null, { trainingRecordId });
+
   return (
     <form
-      action={isEditing ? editSetAction : addSetAction}
+      action={action}
       aria-label="トレーニングセットの追加・変更フォーム"
       className="flex shrink-0 flex-col gap-1 p-4"
       key={`${selectedSetIndex}`} // 編集後フォームを再描画するため key を設定
     >
-      <input name="trainingRecordId" type="hidden" value={trainingRecordId} />
-      <input name="traineeId" type="hidden" value={traineeId} />
-      {isEditing && (
-        <input name="index" type="hidden" value={selectedSetIndex} />
-      )}
       <div className="flex gap-4">
         <div className="flex items-center">
           <label className="mr-2 shrink-0" htmlFor="load">


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更セットの要約です。

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_actions/create-new-record.action.ts:
- `createNewRecordAction`関数のシグネチャが変更され、新しい引数`props`が追加されました。
- `inputSchema`が削除され、代わりに`props`オブジェクトから必要な値を直接取得するようになりました。
- `traineeId`の値は`getSignedInTraineeId`関数を使用して取得されるようになりました。

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/training-events.tsx:
- `TrainingEventsContainer`コンポーネントと関連するいくつかのコードが修正されました。
- `getSignedInTraineeId`関数が削除され、`traineeId`プロパティも削除されました。
- `TrainingEventItem`コンポーネントのフォームの`action`属性に`createNewRecordAction`関数がバインドされるように変更されました。

treco-web/src/app/(header)/(auth)/home/records/[recordId]/_actions/add-set.action.ts:
- `addSetAction`関数のシグネチャが変更され、新しい引数`props`が追加されました。
- `getSignedInTraineeId`関数が使用されて`traineeId`を取得するようになりました。
- `inputSchema`のパースが変更され、`formData`からエントリーを取得してオブジェクトに変換するようになりました。
- `revalidatePath`関数の呼び出し先が`/home/records/${props.trainingRecordId}`に変更されました。

treco-web/src/app/(header)/(auth)/home/records/[recordId]/_actions/edit-set.action.ts:
- `editSetAction`関数のシグネチャが変更され、新しい引数`props`と`formData`が追加されました。
- `getSignedInTraineeId`関数が使用されて`traineeId`を取得するようになりました。

これらの変更は、外部インターフェースやコードの動作に影響を与える可能性があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->