### PR TITLE
delete-button を共通化

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/event-delete.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/event-delete.tsx
@@ -1,67 +1,29 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import { Button } from '@/components/ui/button';
-import { TrashIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
+import { DeleteButton } from '@/components/delete-button';
 
 import { deleteTrainingEventAction } from '../_actions/delete-training-event.action';
+
+function Description() {
+  return (
+    <>
+      この操作は取り消せません。また、関連する以下のデータも一緒に削除されます。
+      <span className="mt-8 block">・トレーニング記録</span>
+    </>
+  );
+}
 
 type Props = {
   trainingCategoryId: string;
   trainingEventId: string;
 };
-export function EventDelete({ trainingCategoryId, trainingEventId }: Props) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
-  async function deleteTrainingEvent() {
-    setIsProcessing(true);
-    try {
-      await deleteTrainingEventAction({ trainingCategoryId, trainingEventId });
-    } finally {
-      setIsProcessing(false);
-    }
-    setIsOpen(false);
-  }
-
+export function EventDelete(props: Props) {
   return (
-    <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
-      <AlertDialogTrigger asChild>
-        <Button className="h-full" variant="destructive">
-          <span className="sr-only">削除</span>
-          <TrashIcon aria-hidden="true" className="h-12 w-14" />
-        </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            本当にトレーニング種目を削除しますか？
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            この操作は取り消せません。また、関連する以下のデータも一緒に削除されます。
-            <span className="mt-8 block">・トレーニング記録</span>
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>やめる</AlertDialogCancel>
-          <AlertDialogAction
-            disabled={isProcessing}
-            onClick={deleteTrainingEvent}
-          >
-            トレーニング種目を削除する
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <DeleteButton
+      action={() => deleteTrainingEventAction(props)}
+      description={<Description />}
+      submitLabel="トレーニング種目を削除する"
+      title="本当にトレーニング種目を削除しますか？"
+    />
   );
 }

--- a/treco-web/src/app/(header)/(auth)/home/categories/_components/category-delete.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/categories/_components/category-delete.tsx
@@ -1,67 +1,29 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import { Button } from '@/components/ui/button';
-import { TrashIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
+import { DeleteButton } from '@/components/delete-button';
 
 import { deleteTrainingCategoryAction } from '../_actions/delete-training-category.action';
+
+function Description() {
+  return (
+    <>
+      この操作は取り消せません。また、関連する以下のデータも一緒に削除されます。
+      <span className="mt-8 block">・トレーニング種目</span>
+      <span className="block">・トレーニング記録</span>
+    </>
+  );
+}
 
 type Props = {
   trainingCategoryId: string;
 };
-export function CategoryDelete({ trainingCategoryId }: Props) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
-  async function deleteTrainingCategory() {
-    setIsProcessing(true);
-    try {
-      await deleteTrainingCategoryAction({ trainingCategoryId });
-    } finally {
-      setIsProcessing(false);
-    }
-    setIsOpen(false);
-  }
-
+export function CategoryDelete(props: Props) {
   return (
-    <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
-      <AlertDialogTrigger asChild>
-        <Button className="h-full" variant="destructive">
-          <span className="sr-only">削除</span>
-          <TrashIcon aria-hidden="true" className="h-12 w-14" />
-        </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            本当にトレーニングカテゴリーを削除しますか？
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            この操作は取り消せません。また、関連する以下のデータも一緒に削除されます。
-            <span className="mt-8 block">・トレーニング種目</span>
-            <span className="block">・トレーニング記録</span>
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>やめる</AlertDialogCancel>
-          <AlertDialogAction
-            disabled={isProcessing}
-            onClick={deleteTrainingCategory}
-          >
-            トレーニングカテゴリーを削除する
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <DeleteButton
+      action={() => deleteTrainingCategoryAction(props)}
+      description={<Description />}
+      submitLabel="トレーニングカテゴリーを削除する"
+      title="本当にトレーニングカテゴリーを削除しますか？"
+    />
   );
 }

--- a/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/set-delete.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/set-delete.tsx
@@ -1,19 +1,6 @@
 'use client';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import { Button } from '@/components/ui/button';
-import { TrashIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
+import { DeleteButton } from '@/components/delete-button';
 
 import { deleteSetAction } from '../_actions';
 
@@ -21,51 +8,13 @@ type Props = {
   trainingRecordId: string;
   trainingSetIndex: number;
 };
-
-export function SetDelete({ trainingRecordId, trainingSetIndex }: Props) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
-  async function deleteTrainingEvent() {
-    setIsProcessing(true);
-    try {
-      await deleteSetAction({
-        trainingRecordId,
-        trainingSetIndex,
-      });
-    } finally {
-      setIsProcessing(false);
-    }
-    setIsOpen(false);
-  }
-
+export function SetDelete(props: Props) {
   return (
-    <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
-      <AlertDialogTrigger asChild>
-        <Button size="icon" variant="destructive">
-          <span className="sr-only">削除</span>
-          <TrashIcon aria-hidden="true" className="h-4 w-4" />
-        </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            本当にトレーニングセットを削除しますか？
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            この操作は取り消せません。
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>やめる</AlertDialogCancel>
-          <AlertDialogAction
-            disabled={isProcessing}
-            onClick={deleteTrainingEvent}
-            type="button"
-          >
-            トレーニングセットを削除する
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <DeleteButton
+      action={() => deleteSetAction(props)}
+      description="この操作は取り消せません"
+      submitLabel="トレーニングセットを削除する"
+      title="本当にトレーニングセットを削除しますか？"
+    />
   );
 }

--- a/treco-web/src/components/delete-button.tsx
+++ b/treco-web/src/components/delete-button.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { TrashIcon } from '@radix-ui/react-icons';
+import { useState } from 'react';
+
+type Props = {
+  action: () => Promise<void>;
+  description: React.ReactNode;
+  submitLabel: string;
+  title: string;
+};
+export function DeleteButton({
+  action,
+  description,
+  submitLabel,
+  title,
+}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  async function handleClick() {
+    setIsProcessing(true);
+    try {
+      await action();
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
+  return (
+    <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
+      <AlertDialogTrigger asChild>
+        <Button size="icon" variant="destructive">
+          <span className="sr-only">削除</span>
+          <TrashIcon aria-hidden="true" className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>やめる</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isProcessing}
+            onClick={handleClick}
+            type="button"
+          >
+            {submitLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

treco-web/src/app/(header)/(auth)/home/categories/[categoryId]/events/_components/event-delete.tsx:
この変更は、`EventDelete`コンポーネントを`DeleteButton`コンポーネントに置き換えるものです。`DeleteButton`コンポーネントは、削除操作を実行するためのボタンとアラートダイアログを提供します。`EventDelete`コンポーネントの`deleteTrainingEvent`関数は、`deleteTrainingEventAction`関数を呼び出すように変更されました。また、`Description`コンポーネントが追加され、削除操作に関連するデータの説明を表示します。これにより、削除ボタンの共通化とコードの再利用性が向上しました。

treco-web/src/app/(header)/(auth)/home/categories/_components/category-delete.tsx:
この変更は、`CategoryDelete`コンポーネントを`DeleteButton`コンポーネントに置き換えるものです。`DeleteButton`コンポーネントは、削除操作を実行するためのボタンとアラートダイアログを提供します。`CategoryDelete`コンポーネントは、`deleteTrainingCategoryAction`関数を呼び出してトレーニングカテゴリーを削除しますが、その処理は`DeleteButton`コンポーネントの`action`プロパティに渡されます。また、削除の確認メッセージや関連データの表示も`DeleteButton`コンポーネント内で行われます。これにより、コードがよりシンプルで再利用可能になりました。

treco-web/src/app/(header)/(auth)/home/records/[recordId]/_components/set-delete.tsx:
この変更は、`SetDelete`コンポーネントを`DeleteButton`コンポーネントに置き換えるものです。`DeleteButton`コンポーネントは、削除アクションを実行するためのボタンと、確認ダイアログを表示する機能を提供します。`SetDelete`コンポーネントは、`deleteSetAction`関数を呼び出す代わりに、`DeleteButton`コンポーネントの`action`プロパティに渡された関数を呼び出すようになります。また、確認ダイアログのタイトルや説明文も変更されています。これにより、削除ボタンの共通化と、コードの簡素化が実現されます。

treco-web/src/components/delete-button.tsx:
この変更は、`DeleteButton`コンポーネントを共通化するためのものです。新しいコンポーネントは、`AlertDialog`と`Button`コンポーネントを使用して削除ダイアログを表示し、削除アクションを実行します。`Props`型には、`action`（削除アクション）、`description`（説明文）、`submitLabel`（送信ボタンのラベル）、`title`（ダイアログのタイトル）が含まれています。`handleClick`関数は非同期で削除アクションを実行し、`isProcessing`ステートを管理します。この変更は、外部インターフェースや動作に影響を与える可能性があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->