### PR TITLE
ログイン/未ログインのリダイレクトを middleware に移動

### DIFF
--- a/treco-web/src/app/(header)/(auth)/layout.tsx
+++ b/treco-web/src/app/(header)/(auth)/layout.tsx
@@ -1,14 +1,8 @@
-import { isAuthenticated } from '@/lib/auth/auth';
-import { redirect } from 'next/navigation';
 import { PropsWithChildren } from 'react';
 
 import { MainMenu } from './main-menu';
 
 export default async function AuthLayout({ children }: PropsWithChildren) {
-  if (!(await isAuthenticated())) {
-    redirect('/');
-  }
-
   return (
     <div className="flex h-full flex-col">
       <main className="grow overflow-auto">{children}</main>

--- a/treco-web/src/app/(public)/page.tsx
+++ b/treco-web/src/app/(public)/page.tsx
@@ -1,17 +1,11 @@
-import { isAuthenticated } from '@/lib/auth/auth';
 import Image from 'next/image';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
 
 import { LoginButtonList } from '../login-button-list';
 import QRCode from './qr.png';
 import SplashImage from './splash.svg';
 
 export default async function Top() {
-  if (await isAuthenticated()) {
-    redirect('/home');
-  }
-
   return (
     <main className="flex w-full flex-col items-center gap-10 px-4 py-14">
       <Image

--- a/treco-web/src/middleware.ts
+++ b/treco-web/src/middleware.ts
@@ -1,11 +1,26 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-export function middleware(req: NextRequest) {
+import { isAuthenticated } from './lib/auth/auth';
+export async function middleware(req: NextRequest) {
   const response = NextResponse.next();
 
   response.headers.set('x-pathname', req.nextUrl.pathname);
   response.headers.set('x-search-params', req.nextUrl.searchParams.toString());
   response.headers.set('x-trainee-id', req.nextUrl.searchParams.toString());
+
+  if (req.nextUrl.pathname === '/' && (await isAuthenticated())) {
+    return NextResponse.redirect('/dashboard', {
+      headers: response.headers,
+      status: 307,
+    });
+  }
+
+  if (/\/home\/.*/.test(req.nextUrl.pathname) && !(await isAuthenticated())) {
+    return NextResponse.redirect('/', {
+      headers: response.headers,
+      status: 307,
+    });
+  }
 
   return response;
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

treco-web/src/app/(header)/(auth)/layout.tsx:
- `AuthLayout`コンポーネントからログイン状態のチェックとリダイレクトを削除し、ミドルウェアに移動しました。
- `isAuthenticated`関数の呼び出しと`redirect`関数の使用が削除されました。
- `AuthLayout`コンポーネントは、ログイン状態のチェックやリダイレクトの責任を持たず、単純に子要素を表示するだけの役割になりました。

treco-web/src/app/(public)/page.tsx:
- ログイン/未ログインのリダイレクトをミドルウェアに移動しました。
- `isAuthenticated`関数が削除され、代わりに`redirect`関数が使用されるようになりました。
- 認証済みの場合には`/home`にリダイレクトされるようになりました。

treco-web/src/middleware.ts:
- `middleware`関数が更新されました。
- `isAuthenticated`関数を使用して、リクエストのパスに基づいてリダイレクトのロジックが追加されました。
- リクエストのパスがルートパス（`/`）であり、ユーザーがログインしている場合は、`/dashboard`にリダイレクトされます。
- リクエストのパスが`/home/`で始まり、ユーザーが未ログインの場合は、`/`にリダイレクトされます。

これらの変更により、ログイン状態に応じた適切なリダイレクトが行われるようになりました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->