### PR TITLE
トレーニング記録削除

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/_actions/delete-record.action.ts
+++ b/treco-web/src/app/(header)/(auth)/home/_actions/delete-record.action.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { PrismaTrainingRecordRepository } from '@/domains/training-record/infrastructures/prisma.repository';
+import { TrainingRecordDeleteUsecase } from '@/domains/training-record/usecases/delete.usecase.ts';
+import { revalidatePath } from 'next/cache';
+
+const trainingRecordDeleteUsecase = new TrainingRecordDeleteUsecase(
+  new PrismaTrainingRecordRepository(),
+);
+
+export async function deleteRecordAction(trainingRecordId: string) {
+  await trainingRecordDeleteUsecase.execute({ trainingRecordId });
+  revalidatePath('/home');
+}

--- a/treco-web/src/app/(header)/(auth)/home/_actions/index.ts
+++ b/treco-web/src/app/(header)/(auth)/home/_actions/index.ts
@@ -1,0 +1,1 @@
+export { TrainingRecordDeleteUsecase } from '@/domains/training-record/usecases/delete.usecase.ts';

--- a/treco-web/src/app/(header)/(auth)/home/page.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/page.tsx
@@ -11,6 +11,7 @@ import { Suspense } from 'react';
 import { object, optional, parse } from 'valibot';
 
 import { Calendar } from './_component/calendar';
+import { RecordDeleteButton } from './record-delete-button';
 
 export const metadata: Metadata = {
   title: 'ホーム',
@@ -74,6 +75,11 @@ async function TrainingRecords({ date }: { date: Date }) {
                 className="h-4 w-4 text-muted-foreground"
               />
             </Link>
+            <RecordDeleteButton
+              trainingCategoryName={record.trainingCategory.name}
+              trainingEventName={record.trainingEvent.name}
+              trainingRecordId={record.trainingRecordId}
+            />
           </div>
           <ul className="rounded-md bg-muted p-4">
             {record.sets.map((set, index) => (

--- a/treco-web/src/app/(header)/(auth)/home/record-delete-button.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/record-delete-button.tsx
@@ -1,0 +1,23 @@
+import { DeleteButton } from '@/components/delete-button';
+
+import { deleteRecordAction } from './_actions/delete-record.action';
+
+type Props = {
+  trainingCategoryName: string;
+  trainingEventName: string;
+  trainingRecordId: string;
+};
+export function RecordDeleteButton({
+  trainingCategoryName,
+  trainingEventName,
+  trainingRecordId,
+}: Props) {
+  return (
+    <DeleteButton
+      action={deleteRecordAction.bind(null, trainingRecordId)}
+      description={`${trainingCategoryName}の${trainingEventName}の記録を削除しようとしています。この操作は取り消せません。`}
+      submitLabel="トレーニング記録を削除する"
+      title="本当にトレーニング記録を削除しますか？"
+    />
+  );
+}

--- a/treco-web/src/domains/training-record/infrastructures/prisma.repository.ts
+++ b/treco-web/src/domains/training-record/infrastructures/prisma.repository.ts
@@ -6,6 +6,14 @@ import { TrainingRecordRepository } from '../usecases/training-record.repository
 export class PrismaTrainingRecordRepository
   implements TrainingRecordRepository
 {
+  async delete(trainingRecordId: string): Promise<void> {
+    await prisma.trainingRecord.delete({
+      where: {
+        trainingRecordId,
+      },
+    });
+  }
+
   async findOneById(trainingRecordId: string): Promise<TrainingRecord> {
     const trainingRecord = await prisma.trainingRecord.findUnique({
       include: {

--- a/treco-web/src/domains/training-record/usecases/delete.usecase.ts.ts
+++ b/treco-web/src/domains/training-record/usecases/delete.usecase.ts.ts
@@ -1,0 +1,13 @@
+import { TrainingRecordRepository } from './training-record.repository';
+
+type Props = {
+  trainingRecordId: string;
+};
+
+export class TrainingRecordDeleteUsecase {
+  constructor(private trainingRecordRepository: TrainingRecordRepository) {}
+
+  execute({ trainingRecordId }: Props) {
+    return this.trainingRecordRepository.delete(trainingRecordId);
+  }
+}

--- a/treco-web/src/domains/training-record/usecases/training-record.repository.ts
+++ b/treco-web/src/domains/training-record/usecases/training-record.repository.ts
@@ -1,6 +1,7 @@
 import { TrainingRecord } from '../models/training-record';
 
 export interface TrainingRecordRepository {
+  delete(trainingRecordId: string): Promise<void>;
   findOneById(trainingRecordId: string): Promise<TrainingRecord>;
   save(trainingRecord: TrainingRecord): Promise<void>;
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

リリースノート:

- `treco-web/src/app/(header)/(auth)/home/_actions/delete-record.action.ts`ファイルには、トレーニング記録を削除するためのアクション関数`deleteRecordAction`が追加されました。この変更は外部インターフェースやコードの動作に影響を与えません。

- `treco-web/src/app/(header)/(auth)/home/page.tsx`ファイルには、`TrainingRecords`コンポーネントに`RecordDeleteButton`が追加されました。これにより、ユーザーはトレーニング記録を削除することができます。この変更は、コードの外部インターフェースや動作に影響を与える可能性があります。

- `treco-web/src/app/(header)/(auth)/home/record-delete-button.tsx`ファイルには、`RecordDeleteButton`コンポーネントが追加されました。このコンポーネントは、トレーニングのカテゴリ名、イベント名、および記録IDを受け取り、削除ボタンを表示します。削除ボタンがクリックされると、`deleteRecordAction`関数が呼び出されます。この変更は、外部インターフェースやコードの動作に影響を与える可能性があります。

- `treco-web/src/domains/training-record/infrastructures/prisma.repository.ts`ファイルには、`PrismaTrainingRecordRepository`クラスに`delete`メソッドが追加されました。このメソッドは、指定されたトレーニング記録IDに基づいてデータベースからトレーニング記録を削除します。この変更は、外部インターフェースやコードの動作に影響を与える可能性があります。

- `treco-web/src/domains/training-record/usecases/delete.usecase.ts.ts`ファイルには、`TrainingRecordDeleteUsecase`クラスが追加され、トレーニング記録を削除するためのメソッドが実装されました。この変更は外部インターフェースやコードの振る舞いに影響を与える可能性があります。

- `treco-web/src/domains/training-record/usecases/training-record.repository.ts`ファイルには、`TrainingRecordRepository`インターフェースに`delete`メソッドが追加されました。新しいメソッドは、トレーニング記録の削除を行うために使用されます。この変更は、コードの外部インターフェースや動作に影響を与える可能性があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->