### PR TITLE
getSignedInTraineeId を cache 化

### DIFF
--- a/treco-web/src/lib/trainee/index.ts
+++ b/treco-web/src/lib/trainee/index.ts
@@ -1,14 +1,12 @@
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { getServerSession } from 'next-auth';
+import { cache } from 'react';
 
-export const SIGNED_IN_TRAINEE_ID_COOKIE_NAME =
-  'SIGNED_IN_TRAINEE_ID_COOKIE_NAME';
-
-export async function getSignedInTraineeId() {
+export const getSignedInTraineeId = cache(async () => {
   const session = await getServerSession(authOptions);
   if (!session?.user) {
     throw new Error('session is not found');
   }
 
   return session.user.traineeId;
-}
+});


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

```
treco-web/src/lib/trainee/index.ts: この変更は、`getSignedInTraineeId`関数をキャッシュ化するものです。変更点は以下の通りです。

- `getSignedInTraineeId`関数が`cache`関数でラップされています。
- `SIGNED_IN_TRAINEE_ID_COOKIE_NAME`定数は削除されました。

これにより、`getSignedInTraineeId`関数の結果がキャッシュされるため、同じリクエスト内で複数回呼び出された場合でも、サーバーセッションの取得が1回しか行われなくなります。外部インターフェースやコードの振る舞いに影響はありません。
```

リリースノート：
- `getSignedInTraineeId`関数がキャッシュ化されました。同じリクエスト内で複数回呼び出された場合でも、サーバーセッションの取得が1回しか行われなくなります。
- `SIGNED_IN_TRAINEE_ID_COOKIE_NAME`定数が削除されました。
- 外部インターフェースやコードの振る舞いには影響はありません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->