### PR TITLE
トップページを static rendering に変更

### DIFF
--- a/treco-web/src/app/(public)/page.tsx
+++ b/treco-web/src/app/(public)/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation';
 
 import { LoginButtonList } from '../login-button-list';
 import QRCode from './qr.png';
+import { RedirectHome } from './redirect-home';
 import SplashImage from './splash.svg';
 
 export default async function Top() {
@@ -42,6 +43,7 @@ export default async function Top() {
           src={QRCode}
         />
       </section>
+      <RedirectHome />
     </main>
   );
 }

--- a/treco-web/src/app/(public)/redirect-home.tsx
+++ b/treco-web/src/app/(public)/redirect-home.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+
+// server component で getServerSession を使うとホーム画面が static rendering にならないのでクライアントコンポーネントで代替する
+// event-emitter を使用しているので middleware でもできない
+
+export function RedirectHome() {
+  const { status } = useSession();
+  const router = useRouter();
+
+  console.log(status);
+  if (status === 'authenticated') {
+    router.replace('/home');
+  }
+
+  return null;
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

リリースノート:

この変更は、トップページに静的レンダリングを導入するためのものです。`RedirectHome`コンポーネントが追加され、メインセクション内に配置されています。これにより、ユーザーがトップページにアクセスした際に自動的にリダイレクトされるようになります。また、`useSession`フックを使用してセッションの状態を取得し、認証済みの場合には`/home`へのリダイレクトが行われます。この変更によって、サーバーコンポーネントでの`getServerSession`の使用が避けられ、ホーム画面の静的レンダリングが可能になります。関数やグローバルデータ構造のシグネチャに変更はありません。外部インターフェースやコードの動作に影響を与える変更もありません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->