### PR TITLE
top ページの redirect 削除漏れ修正

### DIFF
--- a/treco-web/src/app/(public)/page.tsx
+++ b/treco-web/src/app/(public)/page.tsx
@@ -1,7 +1,5 @@
-import { isAuthenticated } from '@/lib/auth/auth';
 import Image from 'next/image';
 import Link from 'next/link';
-import { redirect } from 'next/navigation';
 
 import { LoginButtonList } from '../login-button-list';
 import QRCode from './qr.png';
@@ -9,10 +7,6 @@ import { RedirectHome } from './redirect-home';
 import SplashImage from './splash.svg';
 
 export default async function Top() {
-  if (await isAuthenticated()) {
-    redirect('/home');
-  }
-
   return (
     <main className="flex w-full flex-col items-center gap-10 px-4 py-14">
       <Image

--- a/treco-web/src/app/(public)/page.tsx
+++ b/treco-web/src/app/(public)/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation';
 
 import { LoginButtonList } from '../login-button-list';
 import QRCode from './qr.png';
+import { RedirectHome } from './redirect-home';
 import SplashImage from './splash.svg';
 
 export default async function Top() {
@@ -42,6 +43,7 @@ export default async function Top() {
           src={QRCode}
         />
       </section>
+      <RedirectHome />
     </main>
   );
 }

--- a/treco-web/src/app/(public)/redirect-home.tsx
+++ b/treco-web/src/app/(public)/redirect-home.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+
+// server component で getServerSession を使うとホーム画面が static rendering にならないのでクライアントコンポーネントで代替する
+// event-emitter を使用しているので middleware でもできない
+
+export function RedirectHome() {
+  const { status } = useSession();
+  const router = useRouter();
+
+  console.log(status);
+  if (status === 'authenticated') {
+    router.replace('/home');
+  }
+
+  return null;
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

リリースノート:

- `Top`コンポーネントから`redirect`関数が削除され、代わりに新しい`RedirectHome`コンポーネントが追加されました。
- `isAuthenticated`関数の呼び出しも削除されました。
- ログイン済みのユーザーがトップページにアクセスした場合でも、自動的に`/home`ページにリダイレクトされなくなりました。
- `RedirectHome`コンポーネントは、`next/navigation`から`useRouter`をインポートし、`next-auth/react`から`useSession`をインポートして使用しています。
- `status`が「authenticated」の場合、`router.replace('/home')`が呼び出されてホームページにリダイレクトします。
- この変更は、サーバーコンポーネントでの`getServerSession`の代替手段として導入されました。

重要:
  この変更は、外部インターフェースやコードの振る舞いに影響を与えません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->