### PR TITLE
Day コンポーネントで再描画が発生しないように修正

### DIFF
--- a/treco-web/src/app/(header)/(auth)/home/_component/day.tsx
+++ b/treco-web/src/app/(header)/(auth)/home/_component/day.tsx
@@ -1,23 +1,48 @@
 'use client';
 
+import { TrainingMark } from '@/components/training-mark';
 import { utcDate } from '@/lib/date';
-import React, { PropsWithChildren, memo, useCallback } from 'react';
+import { PropsWithChildren, memo, useCallback } from 'react';
+
+type TrainingMarksProps = {
+  isSkeleton?: boolean;
+  trainingMarkColors?: string[];
+};
+function TrainingMarks({
+  isSkeleton = false,
+  trainingMarkColors,
+}: TrainingMarksProps) {
+  return (
+    <ul className="grid grid-cols-5 gap-y-1">
+      {isSkeleton
+        ? Array.from({ length: 4 }).map((_, index) => (
+            <TrainingMark isSkeleton key={index} size="x-small" />
+          ))
+        : trainingMarkColors?.map((color) => (
+            <TrainingMark color={color} key={color} size="x-small" />
+          ))}
+    </ul>
+  );
+}
 
 type Props = PropsWithChildren<{
   active?: boolean;
-  date: Date;
+  date: string;
   highlight?: boolean;
+  isSkeleton?: boolean;
   mute?: boolean;
   onSelectDate: (date: Date) => void;
+  trainingMarkColors?: string[];
 }>;
 
 export const Day = memo(function Day({
   active,
-  children,
   date,
   highlight,
+  isSkeleton = false,
   mute,
   onSelectDate,
+  trainingMarkColors,
 }: Props) {
   const localDate = utcDate(date).tz('Asia/Tokyo');
 
@@ -29,13 +54,18 @@ export const Day = memo(function Day({
   ].join(' ');
 
   const onClickHandler = useCallback(() => {
-    onSelectDate(date);
+    onSelectDate(new Date(date));
   }, [date, onSelectDate]);
 
   return (
     <button className={style} onClick={onClickHandler}>
       <div className="w-full">{localDate.format('D')}</div>
-      <div className="w-full">{children}</div>
+      <div className="w-full">
+        <TrainingMarks
+          isSkeleton={isSkeleton}
+          trainingMarkColors={trainingMarkColors}
+        />
+      </div>
     </button>
   );
 });


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルの変更内容の要約です：

treco-web/src/app/(header)/(auth)/home/_component/calendar-month.tsx: この変更は、`CalendarMonth`コンポーネント内の再描画を最適化するための修正です。`trainingMarks`配列が更新されるのを防ぐために、`useMemo`フックが導入されました。また、`Day`コンポーネントに新しいプロパティ`isSkeleton`と`trainingMarkColors`が追加されました。これにより、`Day`コンポーネントの再描画が最小限に抑えられ、パフォーマンスが向上します。

treco-web/src/app/(header)/(auth)/home/_component/day.tsx: この変更は、Dayコンポーネントにおいて再描画が発生しないように修正を行っています。具体的な変更点は以下の通りです：

- `TrainingMarks`という新しいコンポーネントが追加されました。これは、トレーニングマークを表示するためのコンポーネントです。
- `Day`コンポーネント内で、`children`の代わりに`TrainingMarks`コンポーネントが表示されるようになりました。
- `isSkeleton`と`trainingMarkColors`という新しいプロパティが`Day`コンポーネントに追加されました。
- `onSelectDate`の引数が`Date`から`string`に変更されました。

これらの変更により、Dayコンポーネントの再描画が最小限に抑えられ、トレーニングマークの表示が改善されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->