### PR TITLE
メインメニューの再描画を抑える

### DIFF
--- a/treco-web/src/app/(header)/(auth)/layout.tsx
+++ b/treco-web/src/app/(header)/(auth)/layout.tsx
@@ -12,7 +12,7 @@ export default async function AuthLayout({ children }: PropsWithChildren) {
   return (
     <div className="flex h-full flex-col">
       <main className="grow overflow-auto">{children}</main>
-      <MainMenu currentDate={new Date()} />
+      <MainMenu />
     </div>
   );
 }

--- a/treco-web/src/app/(header)/(auth)/main-menu.tsx
+++ b/treco-web/src/app/(header)/(auth)/main-menu.tsx
@@ -1,79 +1,20 @@
-'use client';
+import {
+  AccountMenuItem,
+  HomeMenuItem,
+  NewTrainingRecordMenuItem,
+} from './menu-item';
 
-import { SearchParamsDateSchema } from '@/lib/searchParams';
-import { FilePlusIcon, HomeIcon, PersonIcon } from '@radix-ui/react-icons';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
-import { object, optional, parse } from 'valibot';
-
-type Props = {
-  // クライアントコンポーネント内で new Date するとハイドレーションエラーが発生する
-  // layout.tsx では searchParams が取得できないため、 searchParams があるかないかで選択日を判定することができないため、
-  // 選択日が内場合のフォールバック用現在日時だけ受け取り、判定はこのコンポーネントで行う。
-  currentDate: Date;
-};
-
-const SearchParamsSchema = object({
-  date: optional(SearchParamsDateSchema),
-});
-
-export function MainMenu({ currentDate }: Props) {
-  const { date } = parse(
-    SearchParamsSchema,
-    Object.fromEntries(useSearchParams().entries()),
-  );
-  const selectedDate = date ?? currentDate;
-
-  const menus = [
-    {
-      icon: HomeIcon,
-      label: 'ホーム',
-      path: '/home',
-    },
-    {
-      icon: FilePlusIcon,
-      label: 'トレーニング記録',
-      path: `/home/categories?date=${selectedDate.toISOString()}`,
-    },
-    {
-      icon: PersonIcon,
-      label: 'アカウント',
-      path: '/home/account',
-    },
-  ];
-
+export function MainMenu() {
   return (
     <nav
       aria-label="メインメニュー"
-      className="border-t border-t-accent bg-background px-4 py-1"
+      className="border-t border-t-accent bg-background px-4"
     >
       <ul aria-label="メニュー" className="flex justify-evenly">
-        {menus.map((menu) => (
-          <MenuItem {...menu} key={menu.path} />
-        ))}
+        <HomeMenuItem />
+        <NewTrainingRecordMenuItem />
+        <AccountMenuItem />
       </ul>
     </nav>
-  );
-}
-
-function MenuItem({
-  icon: Icon,
-  label,
-  path,
-}: {
-  icon: React.ElementType;
-  label: string;
-  path: string;
-}) {
-  return (
-    <li aria-label={label} key={path}>
-      <Link
-        aria-label={label}
-        href={path}
-        prefetch={!path.includes('?')} // TODO: searchParams がある場合、 prefetch が有効だとうまく遷移しないことがあるので暫定的に無効化
-      >
-        <Icon aria-hidden className="h-8 w-8" />
-      </Link>
-    </li>
   );
 }

--- a/treco-web/src/app/(header)/(auth)/main-menu.tsx
+++ b/treco-web/src/app/(header)/(auth)/main-menu.tsx
@@ -10,7 +10,7 @@ export function MainMenu() {
       aria-label="メインメニュー"
       className="border-t border-t-accent bg-background px-4"
     >
-      <ul aria-label="メニュー" className="flex justify-evenly">
+      <ul className="flex justify-evenly">
         <HomeMenuItem />
         <NewTrainingRecordMenuItem />
         <AccountMenuItem />

--- a/treco-web/src/app/(header)/(auth)/menu-item.tsx
+++ b/treco-web/src/app/(header)/(auth)/menu-item.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useSelectedDate } from '@/app/hooks/use-selected-date';
+import { useToday } from '@/app/hooks/use-today';
+import { FilePlusIcon, HomeIcon, PersonIcon } from '@radix-ui/react-icons';
+import { IconProps } from '@radix-ui/react-icons/dist/types';
+import Link from 'next/link';
+
+type MenuItemProps = {
+  icon: React.ForwardRefExoticComponent<
+    IconProps & React.RefAttributes<SVGSVGElement>
+  >;
+  label: string;
+  path: string;
+};
+export function MenuItem({ icon: Icon, label, path }: MenuItemProps) {
+  return (
+    <li aria-label={label} key={path}>
+      <Link
+        aria-label={label}
+        className="block p-4"
+        href={path}
+        prefetch={!path.includes('?')} // TODO: searchParams がある場合、 prefetch が有効だとうまく遷移しないことがあるので暫定的に無効化
+      >
+        <Icon className="h-8 w-8" />
+      </Link>
+    </li>
+  );
+}
+
+export function NewTrainingRecordMenuItem() {
+  const { selectedDate } = useSelectedDate();
+
+  return (
+    <MenuItem
+      icon={FilePlusIcon}
+      label="トレーニング記録"
+      path={`/home/categories?date=${selectedDate?.toISOString()}`}
+    />
+  );
+}
+
+export function HomeMenuItem() {
+  const { today } = useToday();
+
+  return (
+    <MenuItem
+      icon={HomeIcon}
+      label="ホーム"
+      path={`/home?date=${today?.toISOString()}`}
+    />
+  );
+}
+
+export function AccountMenuItem() {
+  return <MenuItem icon={PersonIcon} label="アカウント" path="/account" />;
+}

--- a/treco-web/src/app/(header)/(auth)/menu-item.tsx
+++ b/treco-web/src/app/(header)/(auth)/menu-item.tsx
@@ -15,14 +15,13 @@ type MenuItemProps = {
 };
 export function MenuItem({ icon: Icon, label, path }: MenuItemProps) {
   return (
-    <li aria-label={label} key={path}>
+    <li key={path}>
       <Link
-        aria-label={label}
         className="block p-4"
         href={path}
         prefetch={!path.includes('?')} // TODO: searchParams がある場合、 prefetch が有効だとうまく遷移しないことがあるので暫定的に無効化
       >
-        <Icon className="h-8 w-8" />
+        <Icon aria-label={label} className="h-8 w-8" />
       </Link>
     </li>
   );

--- a/treco-web/src/app/hooks/use-selected-date.tsx
+++ b/treco-web/src/app/hooks/use-selected-date.tsx
@@ -1,0 +1,20 @@
+import { SearchParamsDateSchema } from '@/lib/searchParams';
+import { useSearchParams } from 'next/navigation';
+import { object, optional, parse } from 'valibot';
+
+import { useToday } from './use-today';
+
+const SearchParamsSchema = object({
+  date: optional(SearchParamsDateSchema),
+});
+
+export function useSelectedDate() {
+  const { today } = useToday();
+
+  const { date } = parse(
+    SearchParamsSchema,
+    Object.fromEntries(useSearchParams().entries()),
+  );
+
+  return { selectedDate: date ?? today };
+}

--- a/treco-web/src/app/hooks/use-today.tsx
+++ b/treco-web/src/app/hooks/use-today.tsx
@@ -1,0 +1,12 @@
+import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
+
+export function useToday() {
+  const [today, setToday] = useState<Date>();
+
+  useEffect(() => {
+    setToday(dayjs().startOf('day').toDate());
+  }, []);
+
+  return { today };
+}


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

以下は、ファイルに対する変更の要約です：

treco-web/src/app/(header)/(auth)/layout.tsx:
- `AuthLayout`コンポーネント内の`MainMenu`コンポーネントの呼び出しを変更しました。以前は、現在の日付を引数として渡していましたが、新しい実装では引数なしで呼び出されます。この変更により、メインメニューの再描画頻度が減り、パフォーマンスが向上する可能性があります。外部インターフェースやコードの動作に影響はありません。

treco-web/src/app/(header)/(auth)/main-menu.tsx:
- `MainMenu`コンポーネントの再描画を抑えるための最適化を行いました。
- `useSearchParams`フックを削除しました。
- メニューアイテムの表示とリンク先の設定を行う`MenuItem`コンポーネントを削除し、代わりに個別のメニューアイテムコンポーネント（`HomeMenuItem`、`NewTrainingRecordMenuItem`、`AccountMenuItem`）を導入しました。
- メニューアイテムの配列`menus`も削除し、代わりに個別のメニューアイテムコンポーネントが使用されるようになりました。これにより、メインメニューの再描画が抑えられ、パフォーマンスが向上することが期待されます。

treco-web/src/app/hooks/use-selected-date.tsx:
- `useSelectedDate`フックを追加しました。このフックは、メインメニューの再描画を抑えるために使用されます。
- 新しいフックは、`SearchParamsSchema`というスキーマを使用してクエリパラメータを解析し、`selectedDate`を返します。
- `selectedDate`は、クエリパラメータの`date`値が存在する場合はその値を、存在しない場合は現在の日付（`today`）を返します。
- この変更は、外部インターフェースやコードの動作に影響を与える可能性があります。

treco-web/src/app/hooks/use-today.tsx:
- `useToday`というカスタムフックを追加しました。このフックは、現在の日付を取得し、`today`という状態変数にセットします。
- `dayjs`ライブラリを使用して、現在の日付を取得しています。
- この変更は、メインメニューの再描画を抑えるために行われており、外部インターフェースやコードの動作に影響を与える可能性があります。

以上が、関連する変更の要約です。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->